### PR TITLE
Updated websocket package URL

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -1,9 +1,9 @@
 package bitfinex
 
 import (
-	"code.google.com/p/go.net/websocket"
 	"encoding/json"
 	"fmt"
+	"golang.org/x/net/websocket"
 	"log"
 	"reflect"
 	"time"


### PR DESCRIPTION
Google Code is shutting down. code.google.com/p/go.net/websocket will stop working soon.

See https://code.google.com/p/support/wiki/ReadOnlyTransition