### PR TITLE
websocket: return error in Subscribe() instead of log.Fatal.

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -102,7 +102,7 @@ func (w *WebSocketService) ClearSubscriptions() {
     w.subscribes = make([]subscribeToChannel, 0)
 }
 
-func (w *WebSocketService) sendSubscribeMessages() {
+func (w *WebSocketService) sendSubscribeMessages() error {
     for _, s := range w.subscribes {
         msg, _ := json.Marshal(SubscribeMsg{
             Event:   "subscribe",
@@ -114,16 +114,19 @@ func (w *WebSocketService) sendSubscribeMessages() {
         err := w.ws.WriteMessage(websocket.TextMessage, msg)
         if err != nil {
             // Can't send message to web socket.
-            log.Fatal(err)
+            return err
         }
     }
+    return nil
 }
 
 // Watch allows to subsribe to channels and watch for new updates.
 // This method supports next channels: book, trade, ticker.
 func (w *WebSocketService) Subscribe() error {
     // Subscribe to each channel
-    w.sendSubscribeMessages()
+    if err := w.sendSubscribeMessages(); err != nil {
+        return err
+    }
 
     var msg string
 


### PR DESCRIPTION
I am writing a service, which receives ticks from bitfinex. As it must run 24/7, and able to reconnect on a network error, log.Fatal is not a correct way of handling connection errors for me.
I think, that it is better to return an error if we can't send subscribe messages.