### PR TITLE
fix examples and default URL

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,10 +15,10 @@ import (
 )
 
 const (
-    DefaultBaseURL        = "wss://api.bitfinex.com/v1"
-    DefaultBaseV2URL      = "wss://api.bitfinex.com/v2"
+    DefaultBaseURL        = "https://api.bitfinex.com/v1/"
+    DefaultBaseV2URL      = "https://api.bitfinex.com/v2/"
     DefaultWebSocketURL   = "wss://api.bitfinex.com/ws/"
-    DefaultWebSocketV2URL = "wss://api.bitfinex.com/ws/2"
+    DefaultWebSocketV2URL = "wss://api.bitfinex.com/ws/2/"
 )
 
 var nonce int64

--- a/examples/account/main.go
+++ b/examples/account/main.go
@@ -1,17 +1,21 @@
 package main
 
 import (
-	"fmt"
-	"github.com/bitfinexcom/bitfinex-api-go"
+    "fmt"
+    "os"
+
+    "github.com/bitfinexcom/bitfinex-api-go"
 )
 
 func main() {
-	client := bitfinex.NewClient().Auth("api-key", "api-secret")
-	info, err := client.Account.Info()
+    key := os.Getenv("BFX_APIKEY")
+    secret := os.Getenv("BFX_SECRET")
+    client := bitfinex.NewClient().Auth(key, secret)
+    info, err := client.Account.Info()
 
-	if err != nil {
-		fmt.Println(err)
-	} else {
-		fmt.Println(info)
-	}
+    if err != nil {
+        fmt.Println(err)
+    } else {
+        fmt.Println(info)
+    }
 }

--- a/examples/account/main.go
+++ b/examples/account/main.go
@@ -1,5 +1,12 @@
 package main
 
+// Set BFX_APIKEY and BFX_SECRET as :
+//
+// export BFX_APIKEY=YOUR_API_KEY
+// export BFX_SECRET=YOUR_API_SECRET
+//
+// you can obtain it from https://www.bitfinex.com/api
+
 import (
     "fmt"
     "os"

--- a/examples/orders/main.go
+++ b/examples/orders/main.go
@@ -7,6 +7,16 @@ import (
     "github.com/bitfinexcom/bitfinex-api-go"
 )
 
+// Set BFX_APIKEY and BFX_SECRET as :
+//
+// export BFX_APIKEY=YOUR_API_KEY
+// export BFX_SECRET=YOUR_API_SECRET
+//
+// you can obtain it from https://www.bitfinex.com/api
+
+// WARNING: IF YOU RUN THIS EXAMPLE WITH A VALID KEY ON PRODUCTION
+//          IT WILL SUBMIT AN ORDER !
+
 func main() {
     key := os.Getenv("BFX_APIKEY")
     secret := os.Getenv("BFX_SECRET")

--- a/examples/orders/main.go
+++ b/examples/orders/main.go
@@ -1,19 +1,23 @@
 package main
 
 import (
-	"fmt"
-	"github.com/bitfinexcom/bitfinex-api-go"
+    "fmt"
+    "os"
+
+    "github.com/bitfinexcom/bitfinex-api-go"
 )
 
 func main() {
-	client := bitfinex.NewClient().Auth("api-key", "api-secret")
+    key := os.Getenv("BFX_APIKEY")
+    secret := os.Getenv("BFX_SECRET")
+    client := bitfinex.NewClient().Auth(key, secret)
 
-	// Sell 0.01 at price 260.99
-	data, err := client.Orders.Create(bitfinex.BTCUSD, -0.01, 260.99, bitfinex.ORDER_TYPE_EXCHANGE_LIMIT)
+    // Sell 0.01BTC at $12.000
+    data, err := client.Orders.Create(bitfinex.BTCUSD, -0.01, 12000, bitfinex.ORDER_TYPE_EXCHANGE_LIMIT)
 
-	if err != nil {
-		fmt.Println("Error:", err)
-	} else {
-		fmt.Println("Response:", data)
-	}
+    if err != nil {
+        fmt.Println("Error:", err)
+    } else {
+        fmt.Println("Response:", data)
+    }
 }

--- a/examples/ws-book/main.go
+++ b/examples/ws-book/main.go
@@ -4,7 +4,7 @@ import (
     "fmt"
     "log"
 
-    "github.com/bfx/bitfinex-api-go"
+    "github.com/bitfinexcom/bitfinex-api-go"
 )
 
 func main() {

--- a/examples/ws-private/main.go
+++ b/examples/ws-private/main.go
@@ -1,26 +1,30 @@
 package main
 
 import (
-	"fmt"
-	"github.com/bitfinexcom/bitfinex-api-go"
+    "fmt"
+    "os"
+
+    "github.com/bitfinexcom/bitfinex-api-go"
 )
 
 func main() {
-	client := bitfinex.NewClient().Auth("api-key", "api-secret")
+    key := os.Getenv("BFX_APIKEY")
+    secret := os.Getenv("BFX_SECRET")
+    client := bitfinex.NewClient().Auth(key, secret)
 
-	dataChan := make(chan bitfinex.TermData)
-	go client.WebSocket.ConnectPrivate(dataChan)
+    dataChan := make(chan bitfinex.TermData)
+    go client.WebSocket.ConnectPrivate(dataChan)
 
-	for {
-		select {
-		case data := <-dataChan:
-			if data.HasError() {
-				// Data has error - websocket channel will be closed.
-				fmt.Println("Error:", data.Error)
-				return
-			} else {
-				fmt.Println("Data:", data)
-			}
-		}
-	}
+    for {
+        select {
+        case data := <-dataChan:
+            if data.HasError() {
+                // Data has error - websocket channel will be closed.
+                fmt.Println("Error:", data.Error)
+                return
+            } else {
+                fmt.Println("Data:", data)
+            }
+        }
+    }
 }

--- a/examples/ws-private/main.go
+++ b/examples/ws-private/main.go
@@ -7,6 +7,13 @@ import (
     "github.com/bitfinexcom/bitfinex-api-go"
 )
 
+// Set BFX_APIKEY and BFX_SECRET as :
+//
+// export BFX_APIKEY=YOUR_API_KEY
+// export BFX_SECRET=YOUR_API_SECRET
+//
+// you can obtain it from https://www.bitfinex.com/api
+
 func main() {
     key := os.Getenv("BFX_APIKEY")
     secret := os.Getenv("BFX_SECRET")

--- a/websocket.go
+++ b/websocket.go
@@ -258,13 +258,11 @@ func (w *WebSocketService) ConnectPrivate(ch chan TermData) {
         Proxy:           http.ProxyFromEnvironment,
     }
 
-    ws, _, err := d.Dial(w.client.WebSocketURL, nil)
-
     if w.client.WebSocketTLSSkipVerify {
         d.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
     }
 
-    ws, _, err = d.Dial(w.client.WebSocketURL, nil)
+    ws, _, err := d.Dial(w.client.WebSocketURL, nil)
     if err != nil {
         ch <- TermData{
             Error: err.Error(),


### PR DESCRIPTION
- fix #21 
- examples now read env `BFX_APIKEY` and `BFX_SECRET` values
- go fmt all example files