### PR TITLE
Add readTimeout To Subscribe

### DIFF
--- a/v1/websocket.go
+++ b/v1/websocket.go
@@ -145,9 +145,9 @@ func (w *WebSocketService) Subscribe(readTimeout time.Duration) error {
 
 	for {
 		if readTimeout == 0 {
-			w.ws.SetReadTimeout(0) //test this 0 or Duration 0
+			w.ws.SetReadDeadline(time.Time{}) // zero Time = no deadline
 		} else {
-			w.ws.SetReadTimeout(time.Now().Add(readTimeout))
+			w.ws.SetReadDeadline(time.Now().Add(readTimeout))
 		}
 		_, p, err := w.ws.ReadMessage()
 		msg = string(p)

--- a/v1/websocket.go
+++ b/v1/websocket.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/bitfinexcom/bitfinex-api-go/utils"
 
@@ -46,6 +47,8 @@ type WebSocketService struct {
 	client *Client
 	// websocket client
 	ws *websocket.Conn
+	//idle time for the websocket before timeout, zero means no timeout
+	readTimeout time.Duration
 	// special web socket for private messages
 	privateWs *websocket.Conn
 	// map internal channels to websocket's
@@ -132,6 +135,10 @@ func (w *WebSocketService) sendSubscribeMessages() error {
 	return nil
 }
 
+func (w *WebSocketService) SetReadTimeout(t time.Duration) {
+	w.readTimeout = t
+}
+
 // Subscribe allows to subsribe to channels and watch for new updates.
 // This method supports next channels: book, trade, ticker.
 func (w *WebSocketService) Subscribe() error {
@@ -143,6 +150,11 @@ func (w *WebSocketService) Subscribe() error {
 	var msg string
 
 	for {
+		if w.readTimeout == 0 {
+			w.ws.SetReadTimeout(0) //test this 0 or Duration 0
+		} else {
+			w.ws.SetReadTimeout(time.Now().Add(w.readTimeout))
+		}
 		_, p, err := w.ws.ReadMessage()
 		msg = string(p)
 		if err != nil {

--- a/v1/websocket.go
+++ b/v1/websocket.go
@@ -47,8 +47,6 @@ type WebSocketService struct {
 	client *Client
 	// websocket client
 	ws *websocket.Conn
-	//idle time for the websocket before timeout, zero means no timeout
-	readTimeout time.Duration
 	// special web socket for private messages
 	privateWs *websocket.Conn
 	// map internal channels to websocket's
@@ -135,13 +133,9 @@ func (w *WebSocketService) sendSubscribeMessages() error {
 	return nil
 }
 
-func (w *WebSocketService) SetReadTimeout(t time.Duration) {
-	w.readTimeout = t
-}
-
 // Subscribe allows to subsribe to channels and watch for new updates.
 // This method supports next channels: book, trade, ticker.
-func (w *WebSocketService) Subscribe() error {
+func (w *WebSocketService) Subscribe(readTimeout time.Duration) error {
 	// Subscribe to each channel
 	if err := w.sendSubscribeMessages(); err != nil {
 		return err
@@ -150,10 +144,10 @@ func (w *WebSocketService) Subscribe() error {
 	var msg string
 
 	for {
-		if w.readTimeout == 0 {
+		if readTimeout == 0 {
 			w.ws.SetReadTimeout(0) //test this 0 or Duration 0
 		} else {
-			w.ws.SetReadTimeout(time.Now().Add(w.readTimeout))
+			w.ws.SetReadTimeout(time.Now().Add(readTimeout))
 		}
 		_, p, err := w.ws.ReadMessage()
 		msg = string(p)


### PR DESCRIPTION
To allow setting the deadline for each ReadMessage of the websocket, I have added a readTimeout time.Duration variable to the function Subscribe. If readTimeout is 0, the socket will not timeout.

There are other options, like having the variable in the WebSocketService struct and have a SetTimeout function. There is also the possibility of having two Subscribe function, one with timeout, other without.