### PR TITLE
Update installation command in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 ## Installation
 
 ``` bash
-go get github.com/bitfinexcom/bitfinex-api-go
+go get github.com/bitfinexcom/bitfinex-api-go/v1
 ```
 
 ## Usage


### PR DESCRIPTION
The installation instructions say to run `go get github.com/bitfinexcom/bitfinex-api-go`, but in this directory there are no buildable source files which causes `go get` to complain.