### PR TITLE
makes Unsubscribe() use the subscription object in order to be able to actually handle multiple subscriptions

### DIFF
--- a/examples/v2/ws-book/main.go
+++ b/examples/v2/ws-book/main.go
@@ -17,11 +17,11 @@ func main() {
 	}
 	c.Websocket.SetReadTimeout(time.Second * 2)
 
-	c.Websocket.AttachEventHandler(func(_ context.Context, ev interface{}) {
+	c.Websocket.AttachEventHandler(func(ev interface{}) {
 		log.Printf("EVENT: %#v", ev)
 	})
 
-	c.Websocket.AttachPublicHandler(func(_ context.Context, ev interface{}) {
+	c.Websocket.AttachPublicHandler(func(ev interface{}) {
 		log.Printf("PUBLIC MSG: %#v", ev)
 	})
 

--- a/tests/integration/v2/websocket_public_test.go
+++ b/tests/integration/v2/websocket_public_test.go
@@ -60,7 +60,7 @@ func TestPublicTicker(t *testing.T) {
 	}
 	c.Websocket.RemovePublicHandler()
 
-	err = c.Websocket.UnsubscribeBySymbol(ctx, msg.Symbol)
+	err = c.Websocket.Unsubscribe(ctx, *msg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestPublicTrades(t *testing.T) {
 	}
 	c.Websocket.RemovePublicHandler()
 
-	err = c.Websocket.UnsubscribeBySymbol(ctx, msg.Symbol)
+	err = c.Websocket.Unsubscribe(ctx, *msg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestPublicBooks(t *testing.T) {
 	}
 	c.Websocket.RemovePublicHandler()
 
-	err = c.Websocket.UnsubscribeBySymbol(ctx, msg.Symbol)
+	err = c.Websocket.Unsubscribe(ctx, *msg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func TestPublicCandles(t *testing.T) {
 	}
 	c.Websocket.RemovePublicHandler()
 
-	err = c.Websocket.UnsubscribeBySymbol(ctx, msg.Key)
+	err = c.Websocket.Unsubscribe(ctx, *msg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/v2/websocket_service.go
+++ b/v2/websocket_service.go
@@ -81,8 +81,8 @@ type bfxWebsocket struct {
 	// The bitfinex API sends us untyped arrays as data, so we have to keep track
 	// of which one belongs where.
 	mu          sync.Mutex
-	pubSubIDs   map[string]struct{}
-	pubChanIDs  map[int64]string // ChannelID -> Symbol map
+	pubSubIDs   map[string]PublicSubscriptionRequest
+	pubChanIDs  map[int64]PublicSubscriptionRequest // ChannelID -> SubscriptionRequest map
 	privSubIDs  map[string]struct{}
 	privChanIDs map[int64]struct{}
 
@@ -100,8 +100,8 @@ func newBfxWebsocket(c *Client, wsURL string) *bfxWebsocket {
 	b := &bfxWebsocket{
 		client:       c,
 		privSubIDs:   map[string]struct{}{},
-		pubSubIDs:    map[string]struct{}{},
-		pubChanIDs:   map[int64]string{},
+		pubSubIDs:    map[string]PublicSubscriptionRequest{},
+		pubChanIDs:   map[int64]PublicSubscriptionRequest{},
 		privChanIDs:  map[int64]struct{}{},
 		webSocketURL: wsURL,
 		mc:           newMsgChan(),
@@ -135,8 +135,8 @@ func (b *bfxWebsocket) Connect() error {
 	b.ws = ws
 
 	b.privSubIDs = map[string]struct{}{}
-	b.pubSubIDs = map[string]struct{}{}
-	b.pubChanIDs = map[int64]string{}
+	b.pubSubIDs = map[string]PublicSubscriptionRequest{}
+	b.pubChanIDs = map[int64]PublicSubscriptionRequest{}
 	b.privChanIDs = map[int64]struct{}{}
 	b.mc = newMsgChan()
 	b.stop = make(chan struct{})


### PR DESCRIPTION
and also fix #52 while we're at it.