### PR TITLE
v2: prevent sender goroutine from spinning on select default

### DIFF
--- a/v2/websocket_service.go
+++ b/v2/websocket_service.go
@@ -159,7 +159,6 @@ func (b *bfxWebsocket) Connect() error {
 func (b *bfxWebsocket) sender() {
 	for {
 		select {
-		default:
 		case <-b.mc.Done():
 			return
 		case msg := <-b.mc.Receive():


### PR DESCRIPTION
Doesn't change the functionality of the select, but prevents the sender goroutine  from spinning.