### PR TITLE
adds the first couple of services for v2 REST endpoints

### DIFF
--- a/examples/v2/rest-orders/main.go
+++ b/examples/v2/rest-orders/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/bitfinexcom/bitfinex-api-go/v2"
+)
+
+// Set BFX_APIKEY and BFX_SECRET as :
+//
+// export BFX_API_KEY=YOUR_API_KEY
+// export BFX_API_SECRET=YOUR_API_SECRET
+//
+// you can obtain it from https://www.bitfinex.com/api
+
+func main() {
+	key := os.Getenv("BFX_API_KEY")
+	secret := os.Getenv("BFX_API_SECRET")
+	c := bitfinex.NewClient().Credentials(key, secret)
+
+	available, err := c.Platform.Status()
+	if err != nil {
+		log.Fatalf("getting status: %s", err)
+	}
+
+	if !available {
+		log.Fatalf("API not available")
+	}
+
+	os, err := c.Orders.History(bitfinex.TradingPrefix + bitfinex.IOTBTC)
+	if err != nil {
+		log.Fatalf("getting orders: %s", err)
+	}
+
+	log.Printf("orders: %#v\n", os)
+}

--- a/examples/v2/ws-private/main.go
+++ b/examples/v2/ws-private/main.go
@@ -26,11 +26,11 @@ func main() {
 		log.Fatalf("connecting authenticated websocket: %s", err)
 	}
 
-	c.Websocket.AttachEventHandler(func(_ context.Context, ev interface{}) {
+	c.Websocket.AttachEventHandler(func(ev interface{}) {
 		log.Printf("EVENT: %#v", ev)
 	})
 
-	c.Websocket.AttachPrivateHandler(func(_ context.Context, msg interface{}) {
+	c.Websocket.AttachPrivateHandler(func(msg interface{}) {
 		log.Printf("PRIV MSG: %#v", msg)
 	})
 

--- a/utils/nonce.go
+++ b/utils/nonce.go
@@ -9,7 +9,7 @@ import (
 var nonce uint64
 
 func init() {
-	nonce = uint64(time.Now().UnixNano())
+	nonce = uint64(time.Now().Unix()) * 1000
 }
 
 // GetNonce is a naive nonce producer that takes the current Unix nano epoch

--- a/v2/errors.go
+++ b/v2/errors.go
@@ -1,0 +1,9 @@
+package bitfinex
+
+import (
+	"errors"
+)
+
+var (
+	ErrNotFound = errors.New("not found")
+)

--- a/v2/orders.go
+++ b/v2/orders.go
@@ -1,0 +1,78 @@
+package bitfinex
+
+import (
+	"fmt"
+	"path"
+)
+
+// OrderService manages the Order endpoint.
+type OrderService struct {
+	client *Client
+}
+
+// All returns all orders for the authenticated account.
+func (s *OrderService) All(symbol string) (OrderSnapshot, error) {
+	req, err := s.client.newAuthenticatedRequest("POST", path.Join("orders", symbol), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw []interface{}
+	_, err = s.client.do(req, &raw)
+	if err != nil {
+		return nil, err
+	}
+
+	os, err := orderSnapshotFromRaw(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return os, nil
+}
+
+// Status retrieves the given order from the API. This is just a wrapper around
+// the All() method, since the API does not provide lookup for a single Order.
+func (s *OrderService) Status(orderID int64) (o Order, err error) {
+	os, err := s.All("")
+	if err != nil {
+		return o, err
+	}
+	if len(os) == 0 {
+		return o, ErrNotFound
+	}
+
+	for _, e := range os {
+		if e.ID == orderID {
+			return e, nil
+		}
+	}
+
+	return o, ErrNotFound
+}
+
+// All returns all orders for the authenticated account.
+func (s *OrderService) History(symbol string) (OrderSnapshot, error) {
+	if symbol == "" {
+		return nil, fmt.Errorf("symbol cannot be empty")
+	}
+
+	req, err := s.client.newAuthenticatedRequest("POST", path.Join("orders", symbol, "hist"), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw []interface{}
+	_, err = s.client.do(req, &raw)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("raw: %#v\n", raw)
+
+	os, err := orderSnapshotFromRaw(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return os, nil
+}

--- a/v2/orders_test.go
+++ b/v2/orders_test.go
@@ -1,0 +1,65 @@
+package bitfinex
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+func TestOrdersAll(t *testing.T) {
+	httpDo = func(_ *http.Client, req *http.Request) (*http.Response, error) {
+		msg := `
+				[
+					[4419360502,null,83283216761,"tIOTBTC",1508281683000,1508281731000,63938,63938,"EXCHANGE LIMIT",null,null,null,null,"CANCELED",null,null,0.0000843,0,0,0,null,null,null,0,0,null],
+					[4419354239,null,83265164211,"tIOTBTC",1508281665000,1508281674000,63976,63976,"EXCHANGE LIMIT",null,null,null,null,"CANCELED",null,null,0.00008425,0,0,0,null,null,null,0,0,null],
+					[4419339620,null,83217673277,"tIOTBTC",1508281618000,1508281653000,64014,64014,"EXCHANGE LIMIT",null,null,null,null,"CANCELED",null,null,0.0000842,0,0,0,null,null,null,0,0,null]
+				]`
+		resp := http.Response{
+			Body:       ioutil.NopCloser(bytes.NewBufferString(msg)),
+			StatusCode: 200,
+		}
+		return &resp, nil
+	}
+
+	orders, err := NewClient().Orders.All("")
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(orders) != 3 {
+		t.Fatalf("expected three orders but got %d", len(orders))
+	}
+}
+
+func TestOrdersHistory(t *testing.T) {
+	httpDo = func(_ *http.Client, req *http.Request) (*http.Response, error) {
+		msg := `
+				[
+					[4419360502,null,83283216761,"tIOTBTC",1508281683000,1508281731000,63938,63938,"EXCHANGE LIMIT",null,null,null,null,"CANCELED",null,null,0.0000843,0,0,0,null,null,null,0,0,null],
+					[4419354239,null,83265164211,"tIOTBTC",1508281665000,1508281674000,63976,63976,"EXCHANGE LIMIT",null,null,null,null,"CANCELED",null,null,0.00008425,0,0,0,null,null,null,0,0,null],
+					[4419339620,null,83217673277,"tIOTBTC",1508281618000,1508281653000,64014,64014,"EXCHANGE LIMIT",null,null,null,null,"CANCELED",null,null,0.0000842,0,0,0,null,null,null,0,0,null]
+				]`
+		resp := http.Response{
+			Body:       ioutil.NopCloser(bytes.NewBufferString(msg)),
+			StatusCode: 200,
+		}
+		return &resp, nil
+	}
+
+	orders, err := NewClient().Orders.History(TradingPrefix + IOTBTC)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(orders) != 3 {
+		t.Errorf("expected three orders but got %d", len(orders))
+	}
+
+	_, err = NewClient().Orders.History("")
+	if err == nil {
+		t.Errorf("expected error when supplying empty symbol but got none")
+	}
+}

--- a/v2/platform_status.go
+++ b/v2/platform_status.go
@@ -1,0 +1,21 @@
+package bitfinex
+
+type PlatformService struct {
+	client *Client
+}
+
+// Status indicates whether the platform is currently operative or not.
+func (p *PlatformService) Status() (bool, error) {
+	req, err := p.client.newRequest("GET", "platform/status", nil, nil)
+	if err != nil {
+		return false, err
+	}
+
+	var s []int
+	_, err = p.client.do(req, &s)
+	if err != nil {
+		return false, err
+	}
+
+	return len(s) > 0 && s[0] == 1, nil
+}

--- a/v2/positions.go
+++ b/v2/positions.go
@@ -1,0 +1,29 @@
+package bitfinex
+
+import ()
+
+// PositionService manages the Position endpoint.
+type PositionService struct {
+	client *Client
+}
+
+// All returns all positions for the authenticated account.
+func (s *PositionService) All() (PositionSnapshot, error) {
+	req, err := s.client.newAuthenticatedRequest("POST", "positions", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw []interface{}
+	_, err = s.client.do(req, &raw)
+	if err != nil {
+		return nil, err
+	}
+
+	os, err := positionSnapshotFromRaw(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return os, nil
+}

--- a/v2/trades.go
+++ b/v2/trades.go
@@ -1,0 +1,31 @@
+package bitfinex
+
+import (
+	"path"
+)
+
+// TradeService manages the Trade endpoint.
+type TradeService struct {
+	client *Client
+}
+
+// All returns all orders for the authenticated account.
+func (s *TradeService) All(symbol string) (TradeSnapshot, error) {
+	req, err := s.client.newAuthenticatedRequest("POST", path.Join("trades", symbol, "hist"), map[string]interface{}{"start": nil, "end": nil, "limit": nil})
+	if err != nil {
+		return nil, err
+	}
+
+	var raw []interface{}
+	_, err = s.client.do(req, &raw)
+	if err != nil {
+		return nil, err
+	}
+
+	os, err := tradeSnapshotFromRaw(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return os, nil
+}

--- a/v2/websocket_service.go
+++ b/v2/websocket_service.go
@@ -299,7 +299,7 @@ func (b *bfxWebsocket) Authenticate(ctx context.Context, filter ...string) error
 	s := &subscriptionRequest{
 		Event:       "auth",
 		APIKey:      b.client.APIKey,
-		AuthSig:     b.client.signPayload(payload),
+		AuthSig:     b.client.sign(payload),
 		AuthPayload: payload,
 		AuthNonce:   nonce,
 		Filter:      filter,


### PR DESCRIPTION
This also includes a breaking change because the REST endpoints use
nonces that are max 53bit, whereas before we used a 64bit number, so
if you've used this lib before you might have to generate a new API
key in order to get rid of the `nonce too small` error message