### PR TITLE
remove default label to fix spinning loop that wastes lots of CPU

### DIFF
--- a/v2/websocket_service.go
+++ b/v2/websocket_service.go
@@ -159,7 +159,6 @@ func (b *bfxWebsocket) Connect() error {
 func (b *bfxWebsocket) sender() {
 	for {
 		select {
-		default:
 		case <-b.mc.Done():
 			return
 		case msg := <-b.mc.Receive():


### PR DESCRIPTION
The default label in this method serves no purpose, but causes the loop to needlessly spin, wasting lots of CPU. Removing the default label fixes this behaviour without changing the functionality of the loop itself.