### PR TITLE
fix: Fixes race condition in ws.Subscribe

### DIFF
--- a/v2/websocket_public.go
+++ b/v2/websocket_public.go
@@ -73,11 +73,13 @@ func (b *bfxWebsocket) Subscribe(ctx context.Context, msg *PublicSubscriptionReq
 		return fmt.Errorf("no subscription request provided")
 	}
 
+	b.subMu.Lock()
 	for _, v := range b.pubChanIDs {
 		if v == *msg {
 			return fmt.Errorf("already subscribed to the channel requested")
 		}
 	}
+	b.subMu.Unlock()
 
 	msg.Event = "subscribe"
 	msg.SubID = utils.GetNonce()


### PR DESCRIPTION
When the web socker service Subscribe function is called while an
already running goroutine receives an `onEvent` message with type
`subscribed`, the map `pubChanIDs` is accessed in both `Subscribe`
function, as a read operation, and in the `onEvent` function, as a write
operation.  This happens at the same time causing a race condition.

Fix involved places a mutex lock inside the `Subscribe` function.
The `onEvent` function already has a mutex lock.

Example of code that produces this race condition is below when a
slice of more than 10 trading pairs are subscribed to and while
some channels are already subscribed to and firing `subscribed`
events and thus writing to the `pubChanIDs` map, the other 
channel / pairs are just accessing `pubChanIDs` to check for the
presence of channel ids.

``` go
// go pseudocode
for _, s := range tradingPairs {
        c.Websocket.Subscribe(ctx, &pubSubReq{Symbol:s}, handler)
}
```
