### PR TITLE
account.go - fix the AccountPairFee struct - use Pairs instead of Pair

### DIFF
--- a/v1/account.go
+++ b/v1/account.go
@@ -5,7 +5,7 @@ type AccountService struct {
 }
 
 type AccountPairFee struct {
-	Pair      string
+	Pairs     string
 	MakerFees float64 `json:"maker_fees,string"`
 	TakerFees float64 `json:"taker_fees,string"`
 }


### PR DESCRIPTION
This fixes the call to account_infos via the **Info** func. It now returns the **Pairs** string correctly after json.Unmarshal is called in v1\client.go **do** func