### PR TITLE
Heartbeat disconnect race condition fix

### DIFF
--- a/tests/integration/v2/reconnect_test.go
+++ b/tests/integration/v2/reconnect_test.go
@@ -545,6 +545,7 @@ func TestHeartbeatTimeoutReconnect(t *testing.T) {
 	// create transport & nonce mocks
 	wsPort := 4001
 	wsService := NewTestWsService(wsPort)
+	wsService.PublishOnConnect(`{"event":"info","version":2}`)
 	err := wsService.Start()
 	if err != nil {
 		t.Fatal(err)
@@ -569,7 +570,7 @@ func TestHeartbeatTimeoutReconnect(t *testing.T) {
 	defer apiClient.Close()
 
 	// begin test
-	wsService.Broadcast(`{"event":"info","version":2}`)
+	// info msg automatically sends
 	msg, err := listener.nextInfoEvent()
 	if err != nil {
 		t.Fatal(err)
@@ -606,12 +607,14 @@ func TestHeartbeatTimeoutReconnect(t *testing.T) {
 	if err = wsService.WaitForClientCount(1); err != nil {
 		t.Fatal(err)
 	}
+	// connection ack
+	// info msg automatically sends
 
 	// expect timeout channel heartbeat
 	time.Sleep(time.Second * 2)
 
 	// check reconnect subscriptions
-	m, err = wsService.WaitForMessage(0, 1)
+	m, err = wsService.WaitForMessage(0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/v2/websocket/channels.go
+++ b/v2/websocket/channels.go
@@ -124,7 +124,6 @@ func (c *Client) handlePrivateChannel(raw []interface{}) error {
 }
 
 func (c *Client) handleHeartbeat(chanID int64) {
-	log.Printf("Heartbeat for channel %d", chanID)
 	c.subscriptions.heartbeat(chanID)
 }
 

--- a/v2/websocket/client.go
+++ b/v2/websocket/client.go
@@ -275,10 +275,9 @@ func (c *Client) listenDisconnect() {
 		c.isConnected = false
 		if e != nil {
 			log.Printf("subscription disconnect: %s", e.Error())
+			c.asynchronous.Close()
+			c.reconnect(e)
 		}
-		log.Print("CLIENT listen disconnect channel closed (heartbeat timeout)")
-		c.asynchronous.Close()
-		c.reconnect(e)
 	case <-c.shutdown: // normal shutdown
 		c.isConnected = false
 	}
@@ -313,12 +312,10 @@ func (c *Client) connect() error {
 
 func (c *Client) reconnect(err error) error {
 	if c.terminal {
-		log.Print("exiting--terminal state")
 		c.exit(err)
 		return err
 	}
 	if !c.parameters.AutoReconnect {
-		log.Print("exiting--no auto reconnect")
 		err := fmt.Errorf("AutoReconnect setting is disabled, do not reconnect: %s", err.Error())
 		c.exit(err)
 		return err
@@ -337,7 +334,6 @@ func (c *Client) reconnect(err error) error {
 	if err != nil {
 		log.Printf("could not reconnect: %s", err.Error())
 	}
-	log.Print("exiting--could not reconnect")
 	return c.exit(err)
 }
 

--- a/v2/websocket/subscriptions.go
+++ b/v2/websocket/subscriptions.go
@@ -2,7 +2,6 @@ package websocket
 
 import (
 	"fmt"
-	"log"
 	"sort"
 	"strings"
 	"sync"

--- a/v2/websocket/subscriptions.go
+++ b/v2/websocket/subscriptions.go
@@ -2,8 +2,6 @@ package websocket
 
 import (
 	"fmt"
-	"log"
-	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -71,12 +69,10 @@ func (s *subscription) activate() {
 }
 
 func (s *subscription) timeout() {
-	log.Print("sub timeout, send to parent disconnect (hb channel disconnect)")
 	s.parentDisconnect <- fmt.Errorf("heartbeat timed out on channel %d", s.ChanID)
 }
 
 func (s *subscription) heartbeat() {
-	debug.PrintStack()
 	if s.hb != nil {
 		s.hb.Stop()
 	}
@@ -177,8 +173,6 @@ func (s *subscriptions) Reset() []*subscription {
 		}
 		sort.Sort(SubscriptionSet(subs))
 	}
-	// TODO wait for hb message to publish prior to closing this
-	log.Print("close hb channel disconnect, hb parent disconnect")
 	close(s.hbChannelDisconnect)
 	close(s.hbParentDisconnect)
 	s.subsBySubID = make(map[string]*subscription)


### PR DESCRIPTION
When integrating the API, I noticed a race condition when intentionally resetting the client's connection.  channel heartbeat changes did terminate and reset the connection, but the heartbeat terminate signal competed with other signals during close which failed to reset the connection.  this change fixes this issue.

I've also made some small adjustments to the test websocket service to more consistently support expected disconnects during tests.