### PR TITLE
Fix 100% cpu usage on websocket dial error

### DIFF
--- a/v2/websocket/transport.go
+++ b/v2/websocket/transport.go
@@ -53,7 +53,6 @@ func (w *ws) Connect() error {
 	log.Printf("connecting ws to %s", w.BaseURL)
 	ws, resp, err := d.Dial(w.BaseURL, nil)
 	if err != nil {
-		close(w.downstream) // signal to parent connection failure thru listen channel
 		if err == websocket.ErrBadHandshake {
 			log.Printf("bad handshake: status code %d", resp.StatusCode)
 		}


### PR DESCRIPTION
Bug:

When the websocket dialing fails (the server could be down for
example), the process enters some kind read loop, and gets stuck at 100%
cpu.

I'm not sure why, but when we signal a close on this channel
(w.downstream) the process enters a loop somewhere, and the CPU gets stuck at
100%.

We don't really need this, since the user is still trying to connect,
and is not expected to be listening for any message, thus he is not expecting the
downstream channel to receive a close message.