### PR TITLE
Maintenance

### DIFF
--- a/examples/v2/book-feed/main.go
+++ b/examples/v2/book-feed/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"github.com/bitfinexcom/bitfinex-api-go/v2"
 	"github.com/bitfinexcom/bitfinex-api-go/v2/websocket"
 	"log"
 	"net/http"
@@ -21,7 +22,7 @@ func main() {
 		for msg := range client.Listen() {
 			log.Printf("recv: %#v", msg)
 			if _, ok := msg.(*websocket.InfoEvent); ok {
-				_, err := client.SubscribeBook(context.Background(), "BTCUSD", websocket.Precision0, websocket.FrequencyRealtime, 1)
+				_, err := client.SubscribeBook(context.Background(), "BTCUSD", bitfinex.Precision0, bitfinex.FrequencyRealtime, 1)
 				if err != nil {
 					log.Printf("could not subscribe to book: %s", err.Error())
 				}

--- a/examples/v2/trade-feed/main.go
+++ b/examples/v2/trade-feed/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"github.com/bitfinexcom/bitfinex-api-go/v2/websocket"
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"os/signal"
+)
+
+func main() {
+	client := websocket.New()
+	err := client.Connect()
+	if err != nil {
+		log.Printf("could not connect: %s", err.Error())
+		return
+	}
+	go func() {
+		for msg := range client.Listen() {
+			log.Printf("recv: %#v", msg)
+			if _, ok := msg.(*websocket.InfoEvent); ok {
+				_, err := client.SubscribeTrades(context.Background(), "tBTCUSD")
+				if err != nil {
+					log.Printf("could not subscribe to trades: %s", err.Error())
+				}
+			}
+		}
+	}()
+	done := make(chan bool, 1)
+	interrupt := make(chan os.Signal)
+	signal.Notify(interrupt, os.Interrupt, os.Kill)
+	go func() {
+		log.Println(http.ListenAndServe("localhost:6060", nil))
+	}()
+	go func() {
+		<-interrupt
+		client.Close()
+		done <- true
+		os.Exit(0)
+	}()
+	<-done
+}

--- a/examples/v2/ws-book/main.go
+++ b/examples/v2/ws-book/main.go
@@ -20,7 +20,7 @@ func main() {
 	// subscribe to BTCUSD book
 	ctx, cxl1 := context.WithTimeout(context.Background(), time.Second*5)
 	defer cxl1()
-	_, err = c.SubscribeBook(ctx, bitfinex.TradingPrefix+bitfinex.BTCUSD, websocket.Precision0, websocket.FrequencyRealtime, 25)
+	_, err = c.SubscribeBook(ctx, bitfinex.TradingPrefix+bitfinex.BTCUSD, bitfinex.Precision0, bitfinex.FrequencyRealtime, 25)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/v2/ws-private/main.go
+++ b/examples/v2/ws-private/main.go
@@ -17,9 +17,12 @@ import (
 
 func main() {
 
+	uri := os.Getenv("BFX_API_URI")
 	key := os.Getenv("BFX_API_KEY")
 	secret := os.Getenv("BFX_API_SECRET")
-	c := websocket.New().Credentials(key, secret)
+	p := websocket.NewDefaultParameters()
+	p.URL = uri
+	c := websocket.NewWithParams(p).Credentials(key, secret)
 
 	err := c.Connect()
 	if err != nil {

--- a/tests/integration/v2/live_websocket_public_test.go
+++ b/tests/integration/v2/live_websocket_public_test.go
@@ -229,7 +229,7 @@ func TestPublicBooks(t *testing.T) {
 
 	ctx, cxl := context.WithTimeout(context.Background(), time.Second*5)
 	defer cxl()
-	id, err := c.SubscribeBook(ctx, bitfinex.TradingPrefix+bitfinex.BTCUSD, websocket.Precision0, websocket.FrequencyRealtime, 1)
+	id, err := c.SubscribeBook(ctx, bitfinex.TradingPrefix+bitfinex.BTCUSD, bitfinex.Precision0, bitfinex.FrequencyRealtime, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/integration/v2/reconnect_test.go
+++ b/tests/integration/v2/reconnect_test.go
@@ -144,7 +144,7 @@ func TestReconnectResubscribeWithAuth(t *testing.T) {
 	assert(t, &expTradeSub, tradeSub)
 
 	// book sub
-	_, err = apiClient.SubscribeBook(context.Background(), "tBTCUSD", websocket.Precision0, websocket.FrequencyRealtime, 25)
+	_, err = apiClient.SubscribeBook(context.Background(), "tBTCUSD", bitfinex.Precision0, bitfinex.FrequencyRealtime, 25)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,8 +164,8 @@ func TestReconnectResubscribeWithAuth(t *testing.T) {
 		Symbol:    "tBTCUSD",
 		SubID:     "nonce3",
 		Channel:   "book",
-		Frequency: string(websocket.FrequencyRealtime),
-		Precision: string(websocket.Precision0),
+		Frequency: string(bitfinex.FrequencyRealtime),
+		Precision: string(bitfinex.Precision0),
 	}
 	assert(t, &expBookSub, bookSub)
 
@@ -256,8 +256,8 @@ func TestReconnectResubscribeWithAuth(t *testing.T) {
 		Symbol:    "tBTCUSD",
 		SubID:     "nonce6",
 		Channel:   "book",
-		Frequency: string(websocket.FrequencyRealtime),
-		Precision: string(websocket.Precision0),
+		Frequency: string(bitfinex.FrequencyRealtime),
+		Precision: string(bitfinex.Precision0),
 		Len:       "25",
 	}
 	assert(t, &expBookSub, bookSub)

--- a/v2/rest/book.go
+++ b/v2/rest/book.go
@@ -7,28 +7,11 @@ import (
 	"strconv"
 )
 
-// Book precision levels
-const (
-	// Aggregate precision levels
-	Precision0 BookPrecision = "P0"
-	Precision2 BookPrecision = "P2"
-	Precision1 BookPrecision = "P1"
-	Precision3 BookPrecision = "P3"
-	// Raw precision
-	PrecisionRawBook BookPrecision = "R0"
-)
-
-// private type
-type bookPrecision string
-
-// BookPrecision provides a typed book precision level.
-type BookPrecision bookPrecision
-
 type BookService struct {
 	Synchronous
 }
 
-func (b *BookService) All(symbol string, precision BookPrecision, priceLevels int) (*bitfinex.BookUpdateSnapshot, error) {
+func (b *BookService) All(symbol string, precision bitfinex.BookPrecision, priceLevels int) (*bitfinex.BookUpdateSnapshot, error) {
 	req := NewRequestWithMethod(path.Join("book", symbol, string(precision)), "GET")
 	req.Params = make(url.Values)
 	req.Params.Add("len", strconv.Itoa(priceLevels))

--- a/v2/rest/book_test.go
+++ b/v2/rest/book_test.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"bytes"
+	"github.com/bitfinexcom/bitfinex-api-go/v2"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -17,7 +18,7 @@ func TestBookAll(t *testing.T) {
 		return &resp, nil
 	}
 
-	book, err := NewClientWithHttpDo(httpDo).Book.All("tBTCUSD", Precision0, 25)
+	book, err := NewClientWithHttpDo(httpDo).Book.All("tBTCUSD", bitfinex.Precision0, 25)
 
 	if err != nil {
 		t.Fatal(err)

--- a/v2/types.go
+++ b/v2/types.go
@@ -81,6 +81,37 @@ type orderSide byte
 // OrderSide provides a typed set of order sides.
 type OrderSide orderSide
 
+// Book precision levels
+const (
+	// Aggregate precision levels
+	Precision0 BookPrecision = "P0"
+	Precision2 BookPrecision = "P2"
+	Precision1 BookPrecision = "P1"
+	Precision3 BookPrecision = "P3"
+	// Raw precision
+	PrecisionRawBook BookPrecision = "R0"
+)
+
+// private type
+type bookPrecision string
+
+// BookPrecision provides a typed book precision level.
+type BookPrecision bookPrecision
+
+const (
+	// FrequencyRealtime book frequency gives updates as they occur in real-time.
+	FrequencyRealtime BookFrequency = "F0"
+	// FrequencyTwoPerSecond delivers two book updates per second.
+	FrequencyTwoPerSecond BookFrequency = "F1"
+	// PriceLevelDefault provides a constant default price level for book subscriptions.
+	PriceLevelDefault int = 25
+)
+
+type bookFrequency string
+
+// BookFrequency provides a typed book frequency.
+type BookFrequency bookFrequency
+
 // OrderNewRequest represents an order to be posted to the bitfinex websocket
 // service.
 type OrderNewRequest struct {

--- a/v2/types.go
+++ b/v2/types.go
@@ -1236,12 +1236,13 @@ const (
 
 // BookUpdate represents an order book price update.
 type BookUpdate struct {
-	Symbol string
-	Price  float64
-	Count  int64
-	Amount float64
-	Side   OrderSide
-	Action BookAction
+	ID     int64      // the book update ID, optional
+	Symbol string     // book symbol
+	Price  float64    // updated price
+	Count  int64      // updated count, optional
+	Amount float64    // updated amount
+	Side   OrderSide  // side
+	Action BookAction // action (add/remove)
 }
 
 type BookUpdateSnapshot struct {
@@ -1268,20 +1269,26 @@ func IsRawBook(precision string) bool {
 
 // NewBookUpdateFromRaw creates a new book update object from raw data.  Precision determines how
 // to interpret the side (baked into Count versus Amount)
-func NewBookUpdateFromRaw(symbol, precision string, raw []interface{}) (b *BookUpdate, err error) {
-	if len(raw) < 3 {
-		return b, fmt.Errorf("data slice too short for book update, expected %d got %d: %#v", 5, len(raw), raw)
+// raw book updates [ID, price, qty], aggregated book updates [price, amount, count]
+func NewBookUpdateFromRaw(symbol, precision string, data []interface{}) (b *BookUpdate, err error) {
+	if len(data) < 3 {
+		return b, fmt.Errorf("data slice too short for book update, expected %d got %d: %#v", 5, len(data), data)
 	}
+	var px float64
+	var id, cnt int64
+	amt := f64ValOrZero(data[2])
 
-	amt := f64ValOrZero(raw[2])
-	px := f64ValOrZero(raw[0])
-	cnt := i64ValOrZero(raw[1])
 	var side OrderSide
-
 	var actionCtrl float64
 	if IsRawBook(precision) {
+		// [ID, price, amount]
+		id = i64ValOrZero(data[0])
+		px = f64ValOrZero(data[1])
 		actionCtrl = px
 	} else {
+		// [price, amount, count]
+		px = f64ValOrZero(data[0])
+		cnt = i64ValOrZero(data[1])
 		actionCtrl = float64(cnt)
 	}
 
@@ -1305,6 +1312,7 @@ func NewBookUpdateFromRaw(symbol, precision string, raw []interface{}) (b *BookU
 		Amount: math.Abs(amt),
 		Side:   side,
 		Action: action,
+		ID:     id,
 	}
 
 	return

--- a/v2/websocket/api.go
+++ b/v2/websocket/api.go
@@ -49,7 +49,7 @@ func (c *Client) SubscribeTrades(ctx context.Context, symbol string) (string, er
 
 // SubscribeBook sends a subscription request for market data for a given symbol, at a given frequency, with a given precision, returning no more than priceLevels price entries.
 // Default values are Precision0, Frequency0, and priceLevels=25.
-func (c *Client) SubscribeBook(ctx context.Context, symbol string, precision BookPrecision, frequency BookFrequency, priceLevel int) (string, error) {
+func (c *Client) SubscribeBook(ctx context.Context, symbol string, precision bitfinex.BookPrecision, frequency bitfinex.BookFrequency, priceLevel int) (string, error) {
 	if priceLevel < 0 {
 		return "", fmt.Errorf("negative price levels not supported: %d", priceLevel)
 	}

--- a/v2/websocket/client.go
+++ b/v2/websocket/client.go
@@ -115,7 +115,7 @@ func NewWebsocketAsynchronousFactory(parameters *Parameters) AsynchronousFactory
 
 // Create returns a new websocket transport.
 func (w *WebsocketAsynchronousFactory) Create() Asynchronous {
-	return newWs(w.parameters.URL)
+	return newWs(w.parameters.URL, w.parameters.LogTransport)
 }
 
 // Client provides a unified interface for users to interact with the Bitfinex V2 Websocket API.

--- a/v2/websocket/client.go
+++ b/v2/websocket/client.go
@@ -35,37 +35,6 @@ const (
 	ChanCandles = "candles"
 )
 
-// Book precision levels
-const (
-	// Aggregate precision levels
-	Precision0 BookPrecision = "P0"
-	Precision2 BookPrecision = "P2"
-	Precision1 BookPrecision = "P1"
-	Precision3 BookPrecision = "P3"
-	// Raw precision
-	PrecisionRawBook BookPrecision = "R0"
-)
-
-// private type
-type bookPrecision string
-
-// BookPrecision provides a typed book precision level.
-type BookPrecision bookPrecision
-
-const (
-	// FrequencyRealtime book frequency gives updates as they occur in real-time.
-	FrequencyRealtime BookFrequency = "F0"
-	// FrequencyTwoPerSecond delivers two book updates per second.
-	FrequencyTwoPerSecond BookFrequency = "F1"
-	// PriceLevelDefault provides a constant default price level for book subscriptions.
-	PriceLevelDefault int = 25
-)
-
-type bookFrequency string
-
-// BookFrequency provides a typed book frequency.
-type BookFrequency bookFrequency
-
 // Events
 const (
 	EventSubscribe   = "subscribe"

--- a/v2/websocket/parameters.go
+++ b/v2/websocket/parameters.go
@@ -15,6 +15,7 @@ type Parameters struct {
 	ResubscribeOnReconnect bool
 
 	HeartbeatTimeout time.Duration
+	LogTransport     bool
 
 	URL string
 }
@@ -29,5 +30,6 @@ func NewDefaultParameters() *Parameters {
 		ShutdownTimeout:        time.Second * 5,
 		ResubscribeOnReconnect: true,
 		HeartbeatTimeout:       time.Second * 10, // HB = 5s
+		LogTransport:           false,            // log transport send/recv
 	}
 }

--- a/v2/websocket/subscriptions.go
+++ b/v2/websocket/subscriptions.go
@@ -250,6 +250,7 @@ func (s *subscriptions) activate(subID string, chanID int64) error {
 	defer s.lock.Unlock()
 	if sub, ok := s.subsBySubID[subID]; ok {
 		if chanID != 0 {
+			//log.Printf("%#v", sub.Request)
 			log.Printf("activated subscription %s %s for channel %d", sub.Request.Channel, sub.Request.Symbol, chanID)
 		}
 		sub.pending = false


### PR DESCRIPTION
- moved shared book precision type to v2/ types.go, out of rest & ws-specific packages
- fixed parsing for raw book updates (aggregated updates were fine)
- added config option to log transport messages to stdout