### PR TITLE
Maintenance

### DIFF
--- a/v2/websocket/api.go
+++ b/v2/websocket/api.go
@@ -87,3 +87,12 @@ func (c *Client) SubmitOrder(ctx context.Context, order *bitfinex.OrderNewReques
 func (c *Client) SubmitCancel(ctx context.Context, cancel *bitfinex.OrderCancelRequest) error {
 	return c.asynchronous.Send(ctx, cancel)
 }
+
+// LookupSubscription looks up a subscription request by ID
+func (c *Client) LookupSubscription(subID string) (*SubscriptionRequest, error) {
+	s, err := c.subscriptions.lookupBySubscriptionID(subID)
+	if err != nil {
+		return nil, err
+	}
+	return s.Request, nil
+}

--- a/v2/websocket/events.go
+++ b/v2/websocket/events.go
@@ -65,6 +65,17 @@ const (
 type ErrorEvent struct {
 	Code    int    `json:"code"`
 	Message string `json:"msg"`
+
+	// also contain members related to subscription reject
+	SubID     string `json:"subId"`
+	Channel   string `json:"channel"`
+	ChanID    int64  `json:"chanId"`
+	Symbol    string `json:"symbol"`
+	Precision string `json:"prec,omitempty"`
+	Frequency string `json:"freq,omitempty"`
+	Key       string `json:"key,omitempty"`
+	Len       string `json:"len,omitempty"`
+	Pair      string `json:"pair"`
 }
 
 type UnsubscribeEvent struct {

--- a/v2/websocket/events.go
+++ b/v2/websocket/events.go
@@ -49,6 +49,19 @@ type Capabilities struct {
 	Positions Capability `json:"positions"`
 }
 
+// error codes pulled from v2 docs & API usage
+const (
+	ErrorCodeUnknownEvent         int = 10000
+	ErrorCodeUnknownPair              = 10001
+	ErrorCodeUnknownBookPrecision     = 10011
+	ErrorCodeUnknownBookLength        = 10012
+	ErrorCodeSubscriptionFailed       = 10300
+	ErrorCodeAlreadySubscribed        = 10301
+	ErrorCodeUnknownChannel           = 10302
+	ErrorCodeUnsubscribeFailed        = 10400
+	ErrorCodeNotSubscribed            = 10401
+)
+
 type ErrorEvent struct {
 	Code    int    `json:"code"`
 	Message string `json:"msg"`


### PR DESCRIPTION
- support bitfinex API error code enumeration
- support subscription error events with members (rather than just msg & code)