### PR TITLE
Implement the rest v2 candle and wallet services

### DIFF
--- a/examples/v2/rest-candles/main.go
+++ b/examples/v2/rest-candles/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+"log"
+bfx "github.com/bitfinexcom/bitfinex-api-go/v2"
+"github.com/bitfinexcom/bitfinex-api-go/v2/rest"
+	"time"
+)
+
+
+func main() {
+	c := rest.NewClient()
+
+
+	log.Printf("1) Query Last Candle")
+	candle, err := c.Candles.Last(bfx.TradingPrefix+bfx.BTCUSD, bfx.FiveMinutes)
+
+	if err != nil {
+		log.Fatalf("getting candle: %s", err)
+	}
+
+	log.Printf("last candle: %#v\n", candle)
+
+	now := time.Now()
+	millis := now.UnixNano() / 1000000
+
+	prior := now.Add(time.Duration(-24) * time.Hour)
+	millisStart := prior.UnixNano() / 1000000
+
+
+	log.Printf("2) Query Candle History with no params")
+	candles, err := c.Candles.History(bfx.TradingPrefix+bfx.BTCUSD, bfx.FiveMinutes)
+
+	if err != nil {
+		log.Fatalf("getting candles: %s", err)
+	}
+
+	log.Printf("length of candles is: %v", len(candles.Snapshot))
+
+	log.Printf("first candle is: %#v\n", candles.Snapshot[0])
+	log.Printf("last candle is: %#v\n", candles.Snapshot[len(candles.Snapshot)-1])
+
+	start := bfx.Mts(millisStart)
+	end := bfx.Mts(millis)
+
+	log.Printf("3) Query Candle History with params")
+	candlesMore, err := c.Candles.HistoryWithQuery(
+		bfx.TradingPrefix+bfx.BTCUSD,
+		bfx.FiveMinutes,
+		start,
+		end,
+		200,
+		bfx.OldestFirst,
+		)
+
+	if err != nil {
+		log.Fatalf("getting candles: %s", err)
+	}
+
+	log.Printf("length of candles is: %v", len(candlesMore.Snapshot))
+	log.Printf("first candle is: %#v\n", candlesMore.Snapshot[0])
+	log.Printf("last candle is: %#v\n", candlesMore.Snapshot[len(candlesMore.Snapshot)-1])
+
+
+
+}
+

--- a/examples/v2/rest-wallet/main.go
+++ b/examples/v2/rest-wallet/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+"flag"
+"log"
+"os"
+"github.com/bitfinexcom/bitfinex-api-go/v2/rest"
+	"github.com/davecgh/go-spew/spew"
+)
+
+
+// Set BFX_APIKEY and BFX_SECRET as :
+//
+// export BFX_API_KEY=YOUR_API_KEY
+// export BFX_API_SECRET=YOUR_API_SECRET
+//
+// you can obtain it from https://www.bitfinex.com/api
+
+func main() {
+	flag.Parse()
+
+	key := os.Getenv("BFX_API_KEY")
+	secret := os.Getenv("BFX_API_SECRET")
+	c := rest.NewClient().Credentials(key, secret)
+
+	wallets, err := c.Wallet.Wallet()
+
+
+	if err != nil {
+		log.Fatalf("getting wallet %s", err)
+	}
+
+	spew.Dump(wallets)
+
+
+
+}
+

--- a/v2/rest/candles.go
+++ b/v2/rest/candles.go
@@ -1,0 +1,132 @@
+package rest
+
+import (
+	"github.com/bitfinexcom/bitfinex-api-go/v2"
+	"path"
+	"strings"
+	"net/url"
+	"fmt"
+)
+
+// CandleService manages the Candles endpoint.
+type CandleService struct {
+	Synchronous
+}
+
+// Return Candles for the public account.
+func (c *CandleService) Last(symbol string, resolution bitfinex.CandleResolution) (*bitfinex.Candle, error) {
+	if symbol == "" {
+		return nil, fmt.Errorf("symbol cannot be empty")
+	}
+
+	segments := []string{ "trade", string(resolution), symbol }
+
+	req := NewRequestWithMethod(path.Join("candles", strings.Join(segments,":"), "LAST"), "GET")
+	req.Params = make(url.Values)
+	raw, err := c.Request(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	cs, err := bitfinex.NewCandleFromRaw(symbol, resolution, raw)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return cs, nil
+}
+
+// Return Candles for the public account.
+func (c *CandleService) History(symbol string, resolution bitfinex.CandleResolution) (*bitfinex.CandleSnapshot, error) {
+	if symbol == "" {
+		return nil, fmt.Errorf("symbol cannot be empty")
+	}
+
+	segments := []string{ "trade", string(resolution), symbol }
+
+	req := NewRequestWithMethod(path.Join("candles", strings.Join(segments,":"), "HIST"), "GET")
+
+	raw, err := c.Request(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	data := make([][]float64, 0, len(raw))
+	for _, ifacearr := range raw {
+		if arr, ok := ifacearr.([]interface{}); ok {
+			sub := make([]float64, 0, len(arr))
+			for _, iface := range arr {
+				if flt, ok := iface.(float64); ok {
+					sub = append(sub, flt)
+				}
+			}
+			data = append(data, sub)
+		}
+	}
+
+	cs, err := bitfinex.NewCandleSnapshotFromRaw(symbol, resolution, data)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return cs, nil
+}
+
+
+// Return Candles for the public account.
+func (c *CandleService) HistoryWithQuery(
+	symbol string,
+	resolution bitfinex.CandleResolution,
+	start bitfinex.Mts,
+	end bitfinex.Mts,
+	limit bitfinex.QueryLimit,
+	sort bitfinex.SortOrder,
+	) (*bitfinex.CandleSnapshot, error) {
+
+		if symbol == "" {
+		return nil, fmt.Errorf("symbol cannot be empty")
+	}
+
+	segments := []string{ "trade", string(resolution), symbol }
+
+	req := NewRequestWithMethod(path.Join("candles", strings.Join(segments,":"), "HIST"), "GET")
+	req.Params = make(url.Values)
+
+	//req.Params.Add("end", strconv.FormatInt(start, 10))
+	//req.Params.Add("end", strconv.FormatInt(start, 10))
+	req.Params.Add("end", string(end))
+	req.Params.Add("start", string(start))
+	req.Params.Add("limit", string(limit))
+	req.Params.Add("sort", string(sort))
+
+	raw, err := c.Request(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	data := make([][]float64, 0, len(raw))
+	for _, ifacearr := range raw {
+		if arr, ok := ifacearr.([]interface{}); ok {
+			sub := make([]float64, 0, len(arr))
+			for _, iface := range arr {
+				if flt, ok := iface.(float64); ok {
+					sub = append(sub, flt)
+				}
+			}
+			data = append(data, sub)
+		}
+	}
+
+	cs, err := bitfinex.NewCandleSnapshotFromRaw(symbol, resolution, data)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return cs, nil
+}

--- a/v2/rest/client.go
+++ b/v2/rest/client.go
@@ -37,6 +37,7 @@ type Client struct {
 	Trades    TradeService
 	Platform  PlatformService
 	Book      BookService
+	Wallet    WalletService
 
 	Synchronous
 }
@@ -93,6 +94,7 @@ func NewClientWithSynchronousURLNonce(sync Synchronous, url string, nonce utils.
 	c.Trades = TradeService{Synchronous: c, requestFactory: c}
 	c.Platform = PlatformService{Synchronous: c}
 	c.Positions = PositionService{Synchronous: c, requestFactory: c}
+	c.Wallet = WalletService{Synchronous: c, requestFactory: c}
 	return c
 }
 

--- a/v2/rest/client.go
+++ b/v2/rest/client.go
@@ -31,6 +31,7 @@ type Client struct {
 	nonce     utils.NonceGenerator
 
 	// service providers
+	Candles   CandleService
 	Orders    OrderService
 	Positions PositionService
 	Trades    TradeService
@@ -88,6 +89,7 @@ func NewClientWithSynchronousURLNonce(sync Synchronous, url string, nonce utils.
 	}
 	c.Orders = OrderService{Synchronous: c, requestFactory: c}
 	c.Book = BookService{Synchronous: c}
+	c.Candles = CandleService{Synchronous: c}
 	c.Trades = TradeService{Synchronous: c, requestFactory: c}
 	c.Platform = PlatformService{Synchronous: c}
 	c.Positions = PositionService{Synchronous: c, requestFactory: c}

--- a/v2/rest/wallet.go
+++ b/v2/rest/wallet.go
@@ -1,0 +1,31 @@
+package rest
+
+import (
+	"github.com/bitfinexcom/bitfinex-api-go/v2"
+	"path"
+)
+
+// WalletService manages data flow for the Wallet API endpoint
+type WalletService struct {
+	requestFactory
+	Synchronous
+}
+
+// All returns all orders for the authenticated account.
+func (s *WalletService) Wallet() (*bitfinex.WalletSnapshot, error) {
+	req, err := s.requestFactory.NewAuthenticatedRequest(path.Join("wallets"))
+	if err != nil {
+		return nil, err
+	}
+	raw, err := s.Request(req)
+	if err != nil {
+		return nil, err
+	}
+
+	os, err := bitfinex.NewWalletSnapshotFromRaw(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return os, nil
+}

--- a/v2/types.go
+++ b/v2/types.go
@@ -34,6 +34,15 @@ const (
 	OneMonth       CandleResolution = "1M"
 )
 
+type Mts int64
+type SortOrder int
+const (
+	OldestFirst         SortOrder = 1
+	NewestFirst         SortOrder = -1
+)
+type QueryLimit int
+const QueryLimitMax QueryLimit = 1000
+
 func CandleResolutionFromString(str string) (CandleResolution, error) {
 	switch str {
 	case string(OneMinute):


### PR DESCRIPTION
Inspired on the work started in bitfinexcom/bitfinex-api-go/pull/84, but adjusted to try and fit with the more recent patterns, and fleshed out

* history and last sections split into separate operations
* added a params struct to manage the optional params on the service
* included the example program to demonstrate usage

Rebased when opened.
I don't know how to write an actual integration test, but the example program works

@prdn @brobits Please review