### PR TITLE
Empty snapshot fixed

### DIFF
--- a/v2/types.go
+++ b/v2/types.go
@@ -1293,13 +1293,11 @@ type BookUpdate struct {
 }
 
 type BookUpdateSnapshot struct {
-	Snapshot []*BookUpdate
+	Symbol   string        // book symbol
+	Snapshot []*BookUpdate // book levels
 }
 
 func NewBookUpdateSnapshotFromRaw(symbol, precision string, raw [][]float64) (*BookUpdateSnapshot, error) {
-	if len(raw) <= 0 {
-		return nil, fmt.Errorf("data slice too short for book snapshot: %#v", raw)
-	}
 	snap := make([]*BookUpdate, 0)
 	for _, f := range raw {
 		b, err := NewBookUpdateFromRaw(symbol, precision, ToInterface(f))
@@ -1307,7 +1305,7 @@ func NewBookUpdateSnapshotFromRaw(symbol, precision string, raw [][]float64) (*B
 			snap = append(snap, b)
 		}
 	}
-	return &BookUpdateSnapshot{Snapshot: snap}, nil
+	return &BookUpdateSnapshot{Symbol: symbol, Snapshot: snap}, nil
 }
 
 func IsRawBook(precision string) bool {


### PR DESCRIPTION
It looks like we should be able to get an empty snapshot if a book is empty.
Currently code doesn't allow it.
So addressing this.