### PR TITLE
Add crc32 orderbook validation

### DIFF
--- a/examples/v2/ws-book/main.go
+++ b/examples/v2/ws-book/main.go
@@ -10,7 +10,10 @@ import (
 )
 
 func main() {
-	c := websocket.New()
+	p := websocket.NewDefaultParameters()
+	// Enable orderbook checksum verification
+	p.ManageOrderbook = true
+	c := websocket.NewWithParams(p)
 
 	err := c.Connect()
 	if err != nil {
@@ -18,16 +21,16 @@ func main() {
 	}
 
 	// subscribe to BTCUSD book
-	ctx, cxl1 := context.WithTimeout(context.Background(), time.Second*5)
-	defer cxl1()
+	ctx, cxl2 := context.WithTimeout(context.Background(), time.Second*5)
+	defer cxl2()
 	_, err = c.SubscribeBook(ctx, bitfinex.TradingPrefix+bitfinex.BTCUSD, bitfinex.Precision0, bitfinex.FrequencyRealtime, 25)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// subscribe to BTCUSD trades
-	ctx, cxl2 := context.WithTimeout(context.Background(), time.Second*5)
-	defer cxl2()
+	ctx, cxl3 := context.WithTimeout(context.Background(), time.Second*5)
+	defer cxl3()
 	_, err = c.SubscribeTrades(ctx, bitfinex.TradingPrefix+bitfinex.BTCUSD)
 	if err != nil {
 		log.Fatal(err)

--- a/v2/types.go
+++ b/v2/types.go
@@ -85,6 +85,16 @@ const (
 	Ask OrderSide = 2
 )
 
+// Settings flags
+
+const (
+	Dec_s int = 9
+  Time_s int = 32
+  Timestamp int = 32768
+  Seq_all int = 65536
+  Checksum int = 131072
+)
+
 type orderSide byte
 
 // OrderSide provides a typed set of order sides.

--- a/v2/websocket/api.go
+++ b/v2/websocket/api.go
@@ -7,11 +7,28 @@ import (
 	"github.com/bitfinexcom/bitfinex-api-go/v2"
 )
 
+type FlagRequest struct {
+	Event string `json:"event"`
+	Flags int `json:"flags"`
+}
+
 // API for end-users to interact with Bitfinex.
 
 // Send publishes a generic message to the Bitfinex API.
 func (c *Client) Send(ctx context.Context, msg interface{}) error {
 	return c.asynchronous.Send(ctx, msg)
+}
+
+func (c *Client) EnableFlag(ctx context.Context, flag int) (string, error) {
+	req := &FlagRequest{
+		Event: "conf",
+		Flags: flag,
+	}
+	err := c.asynchronous.Send(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	return "", nil
 }
 
 // Subscribe sends a subscription request to the Bitfinex API and tracks the subscription status by ID.

--- a/v2/websocket/client.go
+++ b/v2/websocket/client.go
@@ -250,7 +250,7 @@ func (c *Client) dumpParams() {
 	log.Printf("ResubscribeOnReconnect=%t", c.parameters.ResubscribeOnReconnect)
 	log.Printf("HeartbeatTimeout=%s", c.parameters.HeartbeatTimeout)
 	log.Printf("URL=%s", c.parameters.URL)
-	log.Printf("ManageOrderbook=%s", c.parameters.ManageOrderbook)
+	log.Printf("ManageOrderbook=%t", c.parameters.ManageOrderbook)
 }
 
 // Connect to the Bitfinex API, this should only be called once.

--- a/v2/websocket/client.go
+++ b/v2/websocket/client.go
@@ -112,6 +112,7 @@ type Client struct {
 	// subscription manager
 	subscriptions *subscriptions
 	factories     map[string]messageFactory
+	orderbooks    map[string]*Orderbook
 
 	// close signal sent to user on shutdown
 	shutdown chan bool
@@ -180,6 +181,7 @@ func NewWithParamsAsyncFactoryNonce(params *Parameters, async AsynchronousFactor
 		Authentication: NoAuthentication,
 		factories:      make(map[string]messageFactory),
 		subscriptions:  newSubscriptions(params.HeartbeatTimeout),
+		orderbooks:     make(map[string]*Orderbook),
 		nonce:          nonce,
 		isConnected:    false,
 		parameters:     params,
@@ -208,7 +210,7 @@ func extractSymbolResolutionFromKey(subscription string) (symbol string, resolut
 func (c *Client) registerPublicFactories() {
 	c.registerFactory(ChanTicker, newTickerFactory(c.subscriptions))
 	c.registerFactory(ChanTrades, newTradeFactory(c.subscriptions))
-	c.registerFactory(ChanBook, newBookFactory(c.subscriptions))
+	c.registerFactory(ChanBook, newBookFactory(c.subscriptions, c.orderbooks))
 	c.registerFactory(ChanCandles, newCandlesFactory(c.subscriptions))
 }
 
@@ -248,6 +250,7 @@ func (c *Client) dumpParams() {
 	log.Printf("ResubscribeOnReconnect=%t", c.parameters.ResubscribeOnReconnect)
 	log.Printf("HeartbeatTimeout=%s", c.parameters.HeartbeatTimeout)
 	log.Printf("URL=%s", c.parameters.URL)
+	log.Printf("ManageOrderbook=%s", c.parameters.ManageOrderbook)
 }
 
 // Connect to the Bitfinex API, this should only be called once.
@@ -276,6 +279,11 @@ func (c *Client) connect() error {
 	err := c.asynchronous.Connect()
 	if err == nil {
 		c.isConnected = true
+	}
+	// enable flag
+	if c.parameters.ManageOrderbook {
+		ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
+		c.EnableFlag(ctx, bitfinex.Checksum)
 	}
 	return err
 }
@@ -324,6 +332,7 @@ func (c *Client) listenUpstream() {
 		case msg := <-c.asynchronous.Listen():
 			if msg != nil {
 				// Errors here should be non critical so we just log them.
+				log.Printf("[DEBUG]: %s\n", msg)
 				err := c.handleMessage(msg)
 				if err != nil {
 					log.Printf("[WARN]: %s\n", err)

--- a/v2/websocket/orderbook.go
+++ b/v2/websocket/orderbook.go
@@ -1,0 +1,97 @@
+package websocket
+
+import (
+	"fmt"
+	"github.com/bitfinexcom/bitfinex-api-go/v2"
+	"sort"
+	"strings"
+	"hash/crc32"
+	"strconv"
+)
+
+type Orderbook struct {
+	symbol string
+	bids   []*bitfinex.BookUpdate
+	asks   []*bitfinex.BookUpdate
+}
+
+func (ob *Orderbook) SetWithSnapshot(bs *bitfinex.BookUpdateSnapshot) {
+	ob.bids = make([]*bitfinex.BookUpdate, 0)
+	ob.asks = make([]*bitfinex.BookUpdate, 0)
+	for _, order := range bs.Snapshot {
+    if (order.Side == bitfinex.Bid) {
+			ob.bids = append(ob.bids, order)
+		} else {
+			ob.asks = append(ob.asks, order)
+		}
+	}
+}
+
+func (ob *Orderbook) UpdateWith(bu *bitfinex.BookUpdate) {
+	side := &ob.asks
+	if (bu.Side == bitfinex.Bid) {
+		side = &ob.bids
+	}
+
+	// check if first in book
+	if (len(*side) == 0) {
+		*side = append(*side, bu)
+		return
+	}
+
+	// match price level
+	for index, sOrder := range *side {
+		if (sOrder.Price == bu.Price) {
+			if (bu.Count <= 0) {
+				// delete if count is equal to zero
+				*side = append((*side)[:index], (*side)[index+1:]...)
+				return
+			} else {
+				// remove now and we will add in the code below
+				*side = append((*side)[:index], (*side)[index+1:]...)
+			}
+		}
+	}
+	*side = append(*side, bu)
+	// add to the orderbook and sort lowest to highest
+	sort.Slice(*side, func(i, j int) bool {
+		if bu.Side == bitfinex.Ask {
+			return (*side)[i].Price < (*side)[j].Price
+		} else {
+			return (*side)[i].Price > (*side)[j].Price
+		}
+	})
+}
+
+func (ob *Orderbook) Checksum() (uint32) {
+	var checksumItems []string
+	for i := 0; i < 25; i++ {
+		if len(ob.bids) > i {
+			// append bid
+			price := preparePrice((ob.bids)[i].Price)
+			amount := fmt.Sprint((ob.bids)[i].Amount)
+			checksumItems = append(checksumItems, price)
+			checksumItems = append(checksumItems, amount)
+		}
+		if len(ob.asks) > i {
+			// append ask
+			price := preparePrice((ob.asks)[i].Price)
+			amount := fmt.Sprint(-(ob.asks)[i].Amount)
+			checksumItems = append(checksumItems, price)
+			checksumItems = append(checksumItems, amount)
+		}
+	}
+	checksumStrings := strings.Join(checksumItems, ":")
+	return crc32.ChecksumIEEE([]byte(checksumStrings))
+}
+
+func preparePrice(x float64) (string) {
+	// convert so string with 4 significant numbers
+	// i.e 2.1322998 -> 2.1323
+	str := strconv.FormatFloat(x, 'f', 4, 64)
+	// parse back to float
+	f, _:= strconv.ParseFloat(str, 64)
+	// use Sprint (this will remove empty zeros)
+	// i.e 2.0000 -> 2
+	return fmt.Sprint(f)
+}

--- a/v2/websocket/parameters.go
+++ b/v2/websocket/parameters.go
@@ -18,6 +18,7 @@ type Parameters struct {
 	LogTransport     bool
 
 	URL string
+	ManageOrderbook  bool
 }
 
 func NewDefaultParameters() *Parameters {
@@ -27,9 +28,10 @@ func NewDefaultParameters() *Parameters {
 		reconnectTry:           0,
 		ReconnectAttempts:      5,
 		URL:                    productionBaseURL,
+		ManageOrderbook:        false,
 		ShutdownTimeout:        time.Second * 5,
 		ResubscribeOnReconnect: true,
 		HeartbeatTimeout:       time.Second * 10, // HB = 5s
-		LogTransport:           false,            // log transport send/recv
+		LogTransport:           false,           // log transport send/recv
 	}
 }

--- a/v2/websocket/subscriptions.go
+++ b/v2/websocket/subscriptions.go
@@ -251,7 +251,6 @@ func (s *subscriptions) activate(subID string, chanID int64) error {
 	defer s.lock.Unlock()
 	if sub, ok := s.subsBySubID[subID]; ok {
 		if chanID != 0 {
-			//log.Printf("%#v", sub.Request)
 			log.Printf("activated subscription %s %s for channel %d", sub.Request.Channel, sub.Request.Symbol, chanID)
 		}
 		sub.pending = false


### PR DESCRIPTION
As you can see by this material (http://blog.bitfinex.com/api/bitfinex-api-order-books-checksums/) bitfinex ahs introduced orderbook validation to ensure that local clients are kept in sync with the bitfinex orderbook. The node/python and Ruby libraries have been updated to use this functionality.

This pull request adds the ability to toggle `ManageBooks` via the parameters which will keep a local copy of the order book and also check to make sure that it is in sync with the bitfinx orderbook.