### PR TITLE
v1/orderbook: fix panic when sorting for checksum

### DIFF
--- a/v2/websocket/orderbook.go
+++ b/v2/websocket/orderbook.go
@@ -55,6 +55,9 @@ func (ob *Orderbook) UpdateWith(bu *bitfinex.BookUpdate) {
 	*side = append(*side, bu)
 	// add to the orderbook and sort lowest to highest
 	sort.Slice(*side, func(i, j int) bool {
+		if (i >= len(*(side)) || j >= len(*(side))) {
+			return false
+		}
 		if bu.Side == bitfinex.Ask {
 			return (*side)[i].Price < (*side)[j].Price
 		} else {


### PR DESCRIPTION
The checksum for the orderbook was sometimes throwing index out of range if the sides were not balances. This piece of code make sure the sort never operates out of bounds