### PR TITLE
detail InfoEvent; reset subscriptions to nil;

### DIFF
--- a/v2/websocket/client.go
+++ b/v2/websocket/client.go
@@ -352,7 +352,7 @@ func (c *Client) listenUpstream() {
 		case msg := <-c.asynchronous.Listen():
 			if msg != nil {
 				// Errors here should be non critical so we just log them.
-				log.Printf("[DEBUG]: %s\n", msg)
+				// log.Printf("[DEBUG]: %s\n", msg)
 				err := c.handleMessage(msg)
 				if err != nil {
 					log.Printf("[WARN]: %s\n", err)
@@ -458,11 +458,12 @@ func (c *Client) checkResubscription() {
 				log.Printf("could not resubscribe: %s", err.Error())
 			}
 		}
+		c.resetSubscriptions = nil
 	}
 }
 
 // called when an info event is received
-func (c *Client) handleOpen() (error) {
+func (c *Client) handleOpen() error {
 	if c.hasCredentials() {
 		err_auth := c.authenticate(context.Background())
 		if err_auth != nil {

--- a/v2/websocket/events.go
+++ b/v2/websocket/events.go
@@ -10,7 +10,15 @@ type eventType struct {
 }
 
 type InfoEvent struct {
-	Version float64 `json:"version"`
+	Version  float64      `json:"version"`
+	ServerId string       `json:"serverId"`
+	Platform PlatformInfo `json:"platform"`
+	Code     int          `json:"code"`
+	Msg      string       `json:"msg"`
+}
+
+type PlatformInfo struct {
+	Status int `json:"status"`
 }
 
 type RawEvent struct {
@@ -45,15 +53,15 @@ type Capabilities struct {
 
 // error codes pulled from v2 docs & API usage
 const (
-	ErrorCodeUnknownEvent           int = 10000
-	ErrorCodeUnknownPair            int = 10001
-	ErrorCodeUnknownBookPrecision   int = 10011
-	ErrorCodeUnknownBookLength      int = 10012
-	ErrorCodeSubscriptionFailed     int = 10300
-	ErrorCodeAlreadySubscribed      int = 10301
-	ErrorCodeUnknownChannel         int = 10302
-	ErrorCodeUnsubscribeFailed      int = 10400
-	ErrorCodeNotSubscribed          int = 10401
+	ErrorCodeUnknownEvent         int = 10000
+	ErrorCodeUnknownPair          int = 10001
+	ErrorCodeUnknownBookPrecision int = 10011
+	ErrorCodeUnknownBookLength    int = 10012
+	ErrorCodeSubscriptionFailed   int = 10300
+	ErrorCodeAlreadySubscribed    int = 10301
+	ErrorCodeUnknownChannel       int = 10302
+	ErrorCodeUnsubscribeFailed    int = 10400
+	ErrorCodeNotSubscribed        int = 10401
 )
 
 type ErrorEvent struct {
@@ -108,9 +116,11 @@ func (c *Client) handleEvent(msg []byte) error {
 		if err != nil {
 			return err
 		}
-		err_open := c.handleOpen()
-		if err_open != nil {
-			return err_open
+		if i.Code == 0 && i.Version != 0 {
+			err_open := c.handleOpen()
+			if err_open != nil {
+				return err_open
+			}
 		}
 		c.listener <- &i
 	case "auth":


### PR DESCRIPTION
1.  Add more fields to InfoEvent, to differentiate initial connection or inform regarding relevant events;
2. handleOpen should be called only when initial connection has been established;
3. resetSubsribes should be set to nil when resubscribe on reconnect is finished;
4. Comment debug message logs; 