### PR TITLE
Expose local orderbook

### DIFF
--- a/examples/v2/rest-positions/main.go
+++ b/examples/v2/rest-positions/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"log"
+	"github.com/bitfinexcom/bitfinex-api-go/v2/rest"
+	"github.com/davecgh/go-spew/spew"
+)
+
+
+func main() {
+	apikey := ""
+	secKey := ""
+
+	c := rest.NewClient().Credentials(apikey, secKey)
+
+	positions, err := c.Positions.All()
+
+	if err != nil {
+		log.Fatalf("getting wallet %s", err)
+	}
+
+	spew.Dump(positions)
+}
+

--- a/examples/v2/ws-book/main.go
+++ b/examples/v2/ws-book/main.go
@@ -47,8 +47,8 @@ func main() {
 		// Load the latest orderbook
 		ob, _ := c.GetOrderbook(bitfinex.TradingPrefix+bitfinex.BTCUSD)
 		if ob != nil {
-			log.Printf("Orderbook asks: %s", ob.Asks())
-			log.Printf("Orderbook asks: %s", ob.Bids())
+			log.Printf("Orderbook asks: %v", ob.Asks())
+			log.Printf("Orderbook asks: %v", ob.Bids())
 		}
 	}
 }

--- a/examples/v2/ws-book/main.go
+++ b/examples/v2/ws-book/main.go
@@ -43,5 +43,12 @@ func main() {
 		default:
 		}
 		log.Printf("MSG RECV: %#v", obj)
+
+		// Load the latest orderbook
+		ob, _ := c.GetOrderbook(bitfinex.TradingPrefix+bitfinex.BTCUSD)
+		if ob != nil {
+			log.Printf("Orderbook asks: %s", ob.Asks())
+			log.Printf("Orderbook asks: %s", ob.Bids())
+		}
 	}
 }

--- a/v2/websocket/api.go
+++ b/v2/websocket/api.go
@@ -95,6 +95,14 @@ func (c *Client) SubscribeCandles(ctx context.Context, symbol string, resolution
 	return c.Subscribe(ctx, req)
 }
 
+func (c *Client) GetOrderbook(symbol string) (*Orderbook, error) {
+	if val, ok := c.orderbooks[symbol]; ok {
+		// take dereferenced copy of orderbook
+		return val, nil
+	}
+	return nil, fmt.Errorf("Orderbook %s does not exist", symbol)
+}
+
 // SubmitOrder sends an order request.
 func (c *Client) SubmitOrder(ctx context.Context, order *bitfinex.OrderNewRequest) error {
 	return c.asynchronous.Send(ctx, order)

--- a/v2/websocket/orderbook.go
+++ b/v2/websocket/orderbook.go
@@ -16,6 +16,28 @@ type Orderbook struct {
 	asks   []*bitfinex.BookUpdate
 }
 
+// return a dereferenced copy of an orderbook side. This is so consumers can access
+// the book but not change the values that are used to generate the crc32 checksum
+func (ob *Orderbook) copySide(side []*bitfinex.BookUpdate) []bitfinex.BookUpdate {
+	var cpy []bitfinex.BookUpdate
+	for i := 0; i < len(side); i++ {
+		cpy = append(cpy, *side[i])
+	}
+	return cpy
+}
+
+func (ob *Orderbook) Symbol() string {
+	return ob.symbol
+}
+
+func (ob *Orderbook) Asks() []bitfinex.BookUpdate {
+	return ob.copySide(ob.asks)
+}
+
+func (ob *Orderbook) Bids() []bitfinex.BookUpdate {
+	return ob.copySide(ob.bids)
+}
+
 func (ob *Orderbook) SetWithSnapshot(bs *bitfinex.BookUpdateSnapshot) {
 	ob.lock.Lock()
 	defer ob.lock.Unlock()


### PR DESCRIPTION
Exposes functions to allow the consumer to access the locally managed orderbook using the functions `orderbook.Asks()` and `orderbook.Bids()`. The book orders are de-referenced so the consumer is not able to accidentally change the values which would cause for the book to become out of sync and force a crc32 chekcsum invalidation reconnection.