### PR TITLE
Create rest ticker service

### DIFF
--- a/examples/v2/rest-candles/main.go
+++ b/examples/v2/rest-candles/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-"log"
-bfx "github.com/bitfinexcom/bitfinex-api-go/v2"
-"github.com/bitfinexcom/bitfinex-api-go/v2/rest"
+	"log"
+	bfx "github.com/bitfinexcom/bitfinex-api-go/v2"
+	"github.com/bitfinexcom/bitfinex-api-go/v2/rest"
 	"time"
 )
 

--- a/examples/v2/rest-ticker/main.go
+++ b/examples/v2/rest-ticker/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"log"
+	bfx "github.com/bitfinexcom/bitfinex-api-go/v2"
+	"github.com/bitfinexcom/bitfinex-api-go/v2/rest"
+)
+
+
+func main() {
+	c := rest.NewClient()
+	symbols := []string{bfx.TradingPrefix+bfx.BTCUSD, bfx.TradingPrefix+bfx.EOSBTC}
+	tickers, err := c.Tickers.GetMulti(symbols)
+
+	if err != nil {
+		log.Fatalf("getting ticker: %s", err)
+	}
+
+	log.Print(tickers)
+}

--- a/v2/rest/client.go
+++ b/v2/rest/client.go
@@ -35,6 +35,7 @@ type Client struct {
 	Orders    OrderService
 	Positions PositionService
 	Trades    TradeService
+	Tickers   TickerService
 	Platform  PlatformService
 	Book      BookService
 	Wallet    WalletService
@@ -92,6 +93,7 @@ func NewClientWithSynchronousURLNonce(sync Synchronous, url string, nonce utils.
 	c.Book = BookService{Synchronous: c}
 	c.Candles = CandleService{Synchronous: c}
 	c.Trades = TradeService{Synchronous: c, requestFactory: c}
+	c.Tickers = TickerService{Synchronous: c, requestFactory: c}
 	c.Platform = PlatformService{Synchronous: c}
 	c.Positions = PositionService{Synchronous: c, requestFactory: c}
 	c.Wallet = WalletService{Synchronous: c, requestFactory: c}

--- a/v2/rest/tickers.go
+++ b/v2/rest/tickers.go
@@ -1,0 +1,70 @@
+package rest
+
+import (
+	"github.com/bitfinexcom/bitfinex-api-go/v2"
+	"net/url"
+	"strings"
+)
+
+// TradeService manages the Trade endpoint.
+type TickerService struct {
+	requestFactory
+	Synchronous
+}
+
+// All returns all orders for the authenticated account.
+func (s *TickerService) Get(symbol string) (*bitfinex.Ticker, error) {
+	req := NewRequestWithMethod("tickers", "GET")
+	req.Params = make(url.Values)
+	req.Params.Add("symbols", symbol)
+	raw, err := s.Request(req)
+	if err != nil {
+		return nil, err
+	}
+
+	ticker, err := bitfinex.NewTickerFromRestRaw(raw[0].([]interface{}))
+	if err != nil {
+		return nil, err
+	}
+	return ticker, nil
+}
+
+func (s *TickerService) GetMulti(symbols []string) (*[]bitfinex.Ticker, error) {
+	req := NewRequestWithMethod("tickers", "GET")
+	req.Params = make(url.Values)
+	req.Params.Add("symbols", strings.Join(symbols, ","))
+	raw, err := s.Request(req)
+	if err != nil {
+		return nil, err
+	}
+
+	tickers := make([]bitfinex.Ticker, 0)
+	for _, ticker := range raw {
+		t, err := bitfinex.NewTickerFromRestRaw(ticker.([]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		tickers = append(tickers, *t)
+	}
+	return &tickers, nil
+}
+
+func (s *TickerService) All() (*[]bitfinex.Ticker, error) {
+	req := NewRequestWithMethod("tickers", "GET")
+	req.Params = make(url.Values)
+	req.Params.Add("symbols", "ALL")
+	raw, err := s.Request(req)
+	if err != nil {
+		return nil, err
+	}
+
+	tickers := make([]bitfinex.Ticker, 0)
+	for _, ticker := range raw {
+		t, err := bitfinex.NewTickerFromRestRaw(ticker.([]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		tickers = append(tickers, *t)
+	}
+	return &tickers, nil
+}

--- a/v2/types.go
+++ b/v2/types.go
@@ -1330,7 +1330,26 @@ func NewTickerFromRaw(symbol string, raw []interface{}) (t *Ticker, err error) {
 	if len(raw) < 10 {
 		return t, fmt.Errorf("data slice too short for ticker, expected %d got %d: %#v", 10, len(raw), raw)
 	}
+	// funding currency ticker
+	// ignore bid/ask period for now
+	if len(raw) == 13 {
+		t = &Ticker{
+			Symbol:          symbol,
+			Bid:             f64ValOrZero(raw[1]),
+			BidSize:         f64ValOrZero(raw[2]),
+			Ask:             f64ValOrZero(raw[4]),
+			AskSize:         f64ValOrZero(raw[5]),
+			DailyChange:     f64ValOrZero(raw[7]),
+			DailyChangePerc: f64ValOrZero(raw[8]),
+			LastPrice:       f64ValOrZero(raw[9]),
+			Volume:          f64ValOrZero(raw[10]),
+			High:            f64ValOrZero(raw[11]),
+			Low:             f64ValOrZero(raw[12]),
+		}
+		return t, nil
+	}
 
+	// all other tickers
 	t = &Ticker{
 		Symbol:          symbol,
 		Bid:             f64ValOrZero(raw[0]),
@@ -1345,7 +1364,11 @@ func NewTickerFromRaw(symbol string, raw []interface{}) (t *Ticker, err error) {
 		Low:             f64ValOrZero(raw[9]),
 	}
 
-	return
+	return t, nil
+}
+
+func NewTickerFromRestRaw(raw []interface{}) (t *Ticker, err error) {
+	return NewTickerFromRaw(raw[0].(string), raw[1:])
 }
 
 type bookAction byte


### PR DESCRIPTION
Add a new ticker service to the v2 rest interface which allows the functions:

- *tickers.Get( symbol )* - return a types.Ticker object for the given symbol
- *tickers.GetMulti( symbols []string )* - return an array of types.Ticker
- *tickers.All()* - return an array of all types.Ticker