### PR TITLE
Limit channels to 25

### DIFF
--- a/v2/websocket/api.go
+++ b/v2/websocket/api.go
@@ -32,8 +32,11 @@ func (c *Client) EnableFlag(ctx context.Context, flag int) (string, error) {
 
 // Subscribe sends a subscription request to the Bitfinex API and tracks the subscription status by ID.
 func (c *Client) Subscribe(ctx context.Context, req *SubscriptionRequest) (string, error) {
-	c.subscriptions.add(req)
-	err := c.asynchronous.Send(ctx, req)
+	_, err := c.subscriptions.add(req)
+	if err != nil {
+		return "", err
+	}
+	err = c.asynchronous.Send(ctx, req)
 	if err != nil {
 		// propagate send error
 		return "", err

--- a/v2/websocket/client.go
+++ b/v2/websocket/client.go
@@ -536,9 +536,12 @@ func (c *Client) authenticate(ctx context.Context, filter ...string) error {
 	if c.cancelOnDisconnect {
 		s.DMS = DMSCancelOnDisconnect
 	}
-	c.subscriptions.add(s)
+	_, err = c.subscriptions.add(s)
+	if err != nil {
+		return err
+	}
 
-	if err := c.asynchronous.Send(ctx, s); err != nil {
+	if err = c.asynchronous.Send(ctx, s); err != nil {
 		return err
 	}
 	c.Authentication = PendingAuthentication


### PR DESCRIPTION
New Bitfinex API limits means that each connection can only support max 30 channels at once. This pull request adds a limit to the library that enforces this rule (max 25 connections).
