### PR TITLE
Fix v1 api offers, credit, and nonce

### DIFF
--- a/utils/nonce.go
+++ b/utils/nonce.go
@@ -36,7 +36,7 @@ func NewEpochNonceGenerator() *EpochNonceGenerator {
 var nonce uint64
 
 func init() {
-	nonce = uint64(time.Now().UnixNano()) * 1000
+	nonce = uint64(time.Now().UnixNano()) / 1000000
 }
 
 // GetNonce is a naive nonce producer that takes the current Unix nano epoch

--- a/v1/credits.go
+++ b/v1/credits.go
@@ -8,9 +8,9 @@ type Credit struct {
 	Id        int
 	Currency  string
 	Status    string
-	Rate      float64
+	Rate      float64 `json:"rate,string"`
 	Period    float64
-	Amount    float64
+	Amount    float64 `json:"amount,string"`
 	Timestamp string
 }
 

--- a/v1/offers.go
+++ b/v1/offers.go
@@ -26,6 +26,22 @@ type Offer struct {
 	OfferId         int64  `json:"offer_id"`
 }
 
+// Returns an array of Offer
+func (c *OffersService) All() ([]Offer, error) {
+	req, err := c.client.newAuthenticatedRequest("GET", "offers", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	offers := make([]Offer, 0)
+	_, err = c.client.do(req, &offers)
+	if err != nil {
+		return nil, err
+	}
+
+	return offers, nil
+}
+
 // Create new offer for LEND or LOAN a currency, use LEND or LOAN constants as direction
 func (s *OffersService) New(currency string, amount, rate float64, period int64, direction string) (Offer, error) {
 

--- a/v1/offers.go
+++ b/v1/offers.go
@@ -49,11 +49,11 @@ func (s *OffersService) New(currency string, amount, rate float64, period int64,
 		"currency":  currency,
 		"amount":    strconv.FormatFloat(amount, 'f', -1, 32),
 		"rate":      strconv.FormatFloat(rate, 'f', -1, 32),
-		"period":    strconv.FormatInt(period, 10),
+		"period":    period,
 		"direction": direction,
 	}
 
-	req, err := s.client.newAuthenticatedRequest("POST", "offers/new", payload)
+	req, err := s.client.newAuthenticatedRequest("POST", "offer/new", payload)
 
 	if err != nil {
 		return Offer{}, err
@@ -73,10 +73,10 @@ func (s *OffersService) New(currency string, amount, rate float64, period int64,
 func (s *OffersService) Cancel(offerId int64) (Offer, error) {
 
 	payload := map[string]interface{}{
-		"offer_id": strconv.FormatInt(offerId, 10),
+		"offer_id": offerId,
 	}
 
-	req, err := s.client.newAuthenticatedRequest("POST", "offers/cancel", payload)
+	req, err := s.client.newAuthenticatedRequest("POST", "offer/cancel", payload)
 
 	if err != nil {
 		return Offer{}, err

--- a/v1/wallet.go
+++ b/v1/wallet.go
@@ -27,7 +27,7 @@ func (c *WalletService) Transfer(amount float64, currency, from, to string) ([]T
 		"walletto":   to,
 	}
 
-	req, err := c.client.newAuthenticatedRequest("GET", "transfer", payload)
+	req, err := c.client.newAuthenticatedRequest("POST", "transfer", payload)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Description:
Provide an interface to get all offers
Fix credit json parse
v1 nonce use millisecond

### Breaking changes:
- Old api key may have nonce is too small issue when using v1 api. It has to create a new one api key

### New features:
- [ ]

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
