### PR TITLE
Dynamic add subscribe

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 ## Installation
 
 ``` bash
-go get github.com/bitfinexcom/bitfinex-api-go
+go get github.com/whybangbang/bitfinex-api-go
 ```
 
 ## Usage

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 ## Installation
 
 ``` bash
-go get github.com/whybangbang/bitfinex-api-go
+go get github.com/bitfinexcom/bitfinex-api-go
 ```
 
 ## Usage

--- a/v1/websocket.go
+++ b/v1/websocket.go
@@ -122,7 +122,7 @@ func (w *WebSocketService) AddSubscribe(channel string, pair string, c chan []fl
 	w.subscribes = append(w.subscribes, s)
 }
 
-func (w *WebSocketService) AddDirectSendSubscribeMessages(channel string, pair string, c chan []float64) error {
+func (w *WebSocketService) DirectSendSubscribeMessages(channel string, pair string, c chan []float64) error {
 	s := subscribeToChannel{
 		Channel: channel,
 		Pair:    pair,

--- a/v1/websocket.go
+++ b/v1/websocket.go
@@ -126,7 +126,7 @@ func (w *WebSocketService) ClearSubscriptions() {
 	w.subscribes = make([]subscribeToChannel, 0)
 }
 
-func (w *WebSocketService) sendSubscribeMessages() error {
+func (w *WebSocketService) SendSubscribeMessages() error {
 	for _, s := range w.subscribes {
 		msg, _ := json.Marshal(subscribeMsg{
 			Event:   "subscribe",
@@ -146,7 +146,7 @@ func (w *WebSocketService) sendSubscribeMessages() error {
 // This method supports next channels: book, trade, ticker.
 func (w *WebSocketService) Subscribe() error {
 	// Subscribe to each channel
-	if err := w.sendSubscribeMessages(); err != nil {
+	if err := w.SendSubscribeMessages(); err != nil {
 		return err
 	}
 

--- a/v1/websocket.go
+++ b/v1/websocket.go
@@ -122,7 +122,7 @@ func (w *WebSocketService) AddSubscribe(channel string, pair string, c chan []fl
 	w.subscribes = append(w.subscribes, s)
 }
 
-func (w *WebSocketService) DirectSendSubscribeMessages(channel string, pair string, c chan []float64) error {
+func (w *WebSocketService) DynamicAddSubscribe(channel string, pair string, c chan []float64) error {
 	s := subscribeToChannel{
 		Channel: channel,
 		Pair:    pair,


### PR DESCRIPTION
### Description:
when we begin use the api, we only need to subscribe a few trade pairs , users subscribe other pair then we need to dynamic add pair , so we add the function to solve it.

### Breaking changes:
- [ ]

### New features:
- [DynamicAddSubscribe ]

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
