### PR TITLE
Update json tags for Credit to reflect REST response

### DIFF
--- a/v1/credits.go
+++ b/v1/credits.go
@@ -8,9 +8,9 @@ type Credit struct {
 	Id        int
 	Currency  string
 	Status    string
-	Rate      float64
+	Rate      float64 `json:",string"`
 	Period    float64
-	Amount    float64
+	Amount    float64 `json:",string"`
 	Timestamp string
 }
 


### PR DESCRIPTION

### Description:

Some JSON fields are transferred as strings. This will update the struct tags to allow JSON unmarshaling as expected.

### Breaking changes:

None. I hope.

### New features:

`client.Credits.All()` is now usable.

### Fixes:

Error `json: cannot unmarshal string into Go struct field Credit.Rate of type float64` was thrown when trying to unmarshal REST response to `bitfinex.Credit`.

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
