### PR TITLE
Fixed minor typo in Credit and Loan

### DIFF
--- a/v2/types.go
+++ b/v2/types.go
@@ -1131,7 +1131,7 @@ func NewCreditFromRaw(raw []interface{}) (o *Credit, err error) {
 		Side:          sValOrEmpty(raw[2]),
 		MTSCreated:    i64ValOrZero(raw[3]),
 		MTSUpdated:    i64ValOrZero(raw[4]),
-		Amout:         f64ValOrZero(raw[5]),
+		Amount:        f64ValOrZero(raw[5]),
 		Flags:         raw[6],
 		Status:        CreditStatus(sValOrEmpty(raw[7])),
 		Rate:          f64ValOrZero(raw[11]),
@@ -1201,7 +1201,7 @@ type Loan struct {
 	Side          string
 	MTSCreated    int64
 	MTSUpdated    int64
-	Amout         float64
+	Amount        float64
 	Flags         interface{}
 	Status        LoanStatus
 	Rate          float64
@@ -1227,7 +1227,7 @@ func NewLoanFromRaw(raw []interface{}) (o *Loan, err error) {
 		Side:          sValOrEmpty(raw[2]),
 		MTSCreated:    i64ValOrZero(raw[3]),
 		MTSUpdated:    i64ValOrZero(raw[4]),
-		Amout:         f64ValOrZero(raw[5]),
+		Amount:        f64ValOrZero(raw[5]),
 		Flags:         raw[6],
 		Status:        LoanStatus(sValOrEmpty(raw[7])),
 		Rate:          f64ValOrZero(raw[11]),

--- a/v2/types.go
+++ b/v2/types.go
@@ -1104,7 +1104,7 @@ type Credit struct {
 	Side          string
 	MTSCreated    int64
 	MTSUpdated    int64
-	Amout         float64
+	Amount        float64
 	Flags         interface{}
 	Status        CreditStatus
 	Rate          float64


### PR DESCRIPTION
### Description:

Minor type fix. This will break API - but only with an API introduced a few days ago.

### Breaking changes:
- [x] This will break the API for users referencing the misspelled `Amout` in `Credit` and `Loan` types.

### New features:

None.

### Fixes:

Grammar.

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
