### PR TITLE
Remove redundant error check

### DIFF
--- a/v2/websocket/transport.go
+++ b/v2/websocket/transport.go
@@ -120,9 +120,6 @@ func (w *ws) Send(ctx context.Context, msg interface{}) error {
 	w.log.Debug("ws->srv: %s", string(bs))
 	// push request into writer channel
 	w.writeChan <- bs
-	if err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
### Description:
Send() did superfluous error checking. This PR removes it.

### Breaking changes:
None.

### New features:
None.

### Fixes:
- [x] Linter warning.

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
