### PR TITLE
Fix the logging to format the base URL

### DIFF
--- a/v2/websocket/transport.go
+++ b/v2/websocket/transport.go
@@ -67,7 +67,7 @@ func (w *ws) Connect() error {
 
 	d.TLSClientConfig = &tls.Config{InsecureSkipVerify: w.TLSSkipVerify}
 
-	w.log.Info("connecting ws to %s", w.BaseURL)
+	w.log.Infof("connecting ws to %s", w.BaseURL)
 	ws, resp, err := d.Dial(w.BaseURL, nil)
 	if err != nil {
 		if err == websocket.ErrBadHandshake {


### PR DESCRIPTION
### Description:
Fix the logging to format the base URL so when connecting it logs the formatted URL and not "%s www. ...".

### Fixes:
transport.go connecting logging. 

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
