### PR TITLE
adding rate limiting to public client subscriptions, increasing subsc…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+3.0.4
+- Features
+    - adding subscriptions rate limiting
+
 3.0.3
 - Features
     - new websocket manager. Please refer to `/examples/ws` for usage examples.


### PR DESCRIPTION
### Description:
adding a threshold to avoid hitting rate limit when resubscribing to channels

### Breaking changes:
N/A

### New features:
N/A

### Fixes:
- [x] rate limiting fix

### PR status:
- [x] Version bumped
- [x] Change-log updated
