### PR TITLE
ability to instantly subscripbe to 20 channels and rate limit afterwa…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.0.5
+- Adds rate limit to avoid 429 HTTP status codes
+
 3.0.4
 - Adds new rest v2 functions
     - tickers/hist

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 3.0.5
-- Adds rate limit to avoid 429 HTTP status codes
+- Features
+    - rate limit to avoid 429 HTTP status codes when subscribing too often
+- Fixes
+    - auth channel payload event name to avoid invalid channel exception
 
 3.0.4
 - Adds new rest v2 functions

--- a/examples/ws/public-feed-ingest/main.go
+++ b/examples/ws/public-feed-ingest/main.go
@@ -32,27 +32,32 @@ func main() {
 
 	for _, pair := range pairs {
 		tradePld := event.Subscribe{
+			Event:   "subscribe",
 			Channel: "trades",
 			Symbol:  "t" + pair,
 		}
 
 		tickPld := event.Subscribe{
+			Event:   "subscribe",
 			Channel: "ticker",
 			Symbol:  "t" + pair,
 		}
 
 		candlesPld := event.Subscribe{
+			Event:   "subscribe",
 			Channel: "candles",
 			Key:     "trade:1m:t" + pair,
 		}
 
 		rawBookPld := event.Subscribe{
+			Event:     "subscribe",
 			Channel:   "book",
 			Precision: "R0",
 			Symbol:    "t" + pair,
 		}
 
 		bookPld := event.Subscribe{
+			Event:     "subscribe",
 			Channel:   "book",
 			Precision: "P0",
 			Frequency: "F0",
@@ -67,16 +72,19 @@ func main() {
 	}
 
 	derivStatusPld := event.Subscribe{
+		Event:   "subscribe",
 		Channel: "status",
 		Key:     "deriv:tBTCF0:USTF0",
 	}
 
 	liqStatusPld := event.Subscribe{
+		Event:   "subscribe",
 		Channel: "status",
 		Key:     "liq:global",
 	}
 
 	fundingPairTrade := event.Subscribe{
+		Event:   "subscribe",
 		Channel: "trades",
 		Symbol:  "fUSD",
 	}

--- a/pkg/mux/client/client.go
+++ b/pkg/mux/client/client.go
@@ -88,7 +88,6 @@ func (c *Client) Private(key, sec, url string, dms int) (*Client, error) {
 // Subscribe takes subscription payload as per docs and subscribes client to it.
 // We keep track of subscriptions so that when client failes, we can resubscribe.
 func (c *Client) Subscribe(sub event.Subscribe) error {
-	sub.Event = "subscribe"
 	if err := c.Send(sub); err != nil {
 		return err
 	}

--- a/pkg/mux/mux.go
+++ b/pkg/mux/mux.go
@@ -103,8 +103,8 @@ func (m *Mux) Close() bool {
 	return true
 }
 
-// Subscribe - given the details in form of event.Subscribe,
-// queues the subscriptions for eventual submission
+// Subscribe - given the details in form of event.Subscribe, subscribes client to public
+// channels. If rate limit is reached, calls itself recursively after 1s with same params
 func (m *Mux) Subscribe(sub event.Subscribe) *Mux {
 	if m.Err != nil {
 		return m
@@ -123,7 +123,7 @@ func (m *Mux) Subscribe(sub event.Subscribe) *Mux {
 		return m
 	}
 
-	if err := m.publicClients[m.cid].Subscribe(sub); err != nil {
+	if m.Err = m.publicClients[m.cid].Subscribe(sub); m.Err != nil {
 		return m
 	}
 

--- a/pkg/mux/mux.go
+++ b/pkg/mux/mux.go
@@ -76,7 +76,7 @@ func (m *Mux) WithDeadManSwitch() *Mux {
 	return m
 }
 
-// WithAPISEC accepts and persists api sec
+// WithAPISEC accepts and persists api secret
 func (m *Mux) WithAPISEC(sec string) *Mux {
 	m.apisec = sec
 	return m
@@ -143,7 +143,8 @@ func (m *Mux) Start() *Mux {
 	}
 
 	m.watchRateLimit()
-	return m.addPublicClient()
+	m.addPublicClient()
+	return m
 }
 
 // Listen accepts a callback func that will get called each time mux
@@ -159,7 +160,7 @@ func (m *Mux) Listen(cb func(interface{}, error)) error {
 		select {
 		case ms, ok := <-m.publicChan:
 			if !ok {
-				return errors.New("channel has closed unexpectedly")
+				return errors.New("public channel has closed unexpectedly")
 			}
 			if ms.Err != nil {
 				cb(nil, fmt.Errorf("conn:%d has failed | err:%s | reconnecting", ms.CID, ms.Err))
@@ -195,7 +196,7 @@ func (m *Mux) Listen(cb func(interface{}, error)) error {
 			cb(nil, fmt.Errorf("unrecognized msg signature: %s", ms.Data))
 		case ms, ok := <-m.privateChan:
 			if !ok {
-				return errors.New("channel has closed unexpectedly")
+				return errors.New("private channel has closed unexpectedly")
 			}
 			if ms.Err != nil {
 				cb(nil, fmt.Errorf("err: %s | reconnecting", ms.Err))


### PR DESCRIPTION
### Description:
Rate limiting feature. It will allow 20 instant subscriptions followed by 1 subscription every 3s as per docs.

### Breaking changes:
- N/A

### New features:
- [x] rate limiting

### Fixes:
- [x] client does not panic when rate limit is reached and 429 status code is received
- [x] auth channel payload event name assignment fix to avoid invalid channel exception

### PR status:
- [x] Version bumped
- [x] Change-log updated
