### PR TITLE
an important fix connected to the Conf method

### DIFF
--- a/pkg/models/currency/currency.go
+++ b/pkg/models/currency/currency.go
@@ -128,12 +128,22 @@ func parseExchangeMap(config map[string]Conf, raw []interface{}) {
 		if val, ok := config[base]; ok {
 			val.Pairs = append(val.Pairs, symbol)
 			config[base] = val
+		} else {
+			config[base] = Conf{
+				Currency: base,
+				Pairs:    []string{symbol},
+			}
 		}
 
 		// append if quote exists in configs
 		if val, ok := config[quote]; ok {
 			val.Pairs = append(val.Pairs, symbol)
 			config[quote] = val
+		} else {
+			config[quote] = Conf{
+				Currency: quote,
+				Pairs:    []string{symbol},
+			}
 		}
 	}
 }

--- a/v2/rest/currencies.go
+++ b/v2/rest/currencies.go
@@ -40,7 +40,7 @@ func (cs *CurrenciesService) Conf(label, symbol, unit, explorer, pairs bool) ([]
 	}
 
 	// add mapping to raw data
-	parsedRaw := make([]currency.RawConf, len(raw))
+	parsedRaw := make([]currency.RawConf, 0, len(raw))
 	for index, d := range raw {
 		parsedRaw = append(parsedRaw, currency.RawConf{Mapping: segments[index], Data: d})
 	}


### PR DESCRIPTION
### Description:
1. After this call of the "Conf" method, the "currenciesConf" slice will be always empty, 
because the "parseExchangeMap" method doesn't add a new config to the common map 
```go
currenciesConf, err := client.Currencies.Conf(false, false, false, false, true)
if err != nil {
	return nil, err
}
```
2. The "Conf" method creates the "parsedRaw" slice with the specified length, 
but afterward, new elements are added by "append". 
As result, we have redundant empty elements in the "parsedRaw" slice.


### Breaking changes:
-

### New features:
- 

### Fixes:
- [x] currencies configuration fix

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
